### PR TITLE
[BUGFIX] fixed authentication service on empty tokenInfo

### DIFF
--- a/Classes/Service/AuthenticationService.php
+++ b/Classes/Service/AuthenticationService.php
@@ -313,7 +313,7 @@ class AuthenticationService extends \TYPO3\CMS\Core\Authentication\Authenticatio
      */
     public function getUser()
     {
-        if ($this->login['status'] !== 'login') {
+        if ($this->login['status'] !== 'login' || empty($this->tokenInfo)) {
             return false;
         }
 


### PR DESCRIPTION
We need to check if the `$this->tokenInfo` is empty inside the `AuthenticationService->getUser()`. It should return false if it's empty.

Currently the getUser() function returns the first fe_user if the tokenInfo is empty. 

My use case:

Im using the sf_register extension, which also uses an AuthenticationService. However the Auth0 Extension is returning a wrong fe_user before the sf_register extension triggers.