### PR TITLE
[TASK] register backend login provider only when backend login is enabled

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -76,10 +76,12 @@ if ($configuration->isEnableBackendLogin()) {
     ]
 );
 
-// Register backend login provider
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['backend']['loginProviders'][Auth0Provider::LOGIN_PROVIDER] = [
-    'provider' => Auth0Provider::class,
-    'sorting' => 25,
-    'iconIdentifier' => 'auth0LoginProvider',
-    'label' => 'LLL:EXT:auth0/Resources/Private/Language/locallang.xlf:backendLogin.switch.label'
-];
+if ($configuration->isEnableBackendLogin()) {
+    // Register backend login provider
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['backend']['loginProviders'][Auth0Provider::LOGIN_PROVIDER] = [
+        'provider' => Auth0Provider::class,
+        'sorting' => 25,
+        'iconIdentifier' => 'auth0LoginProvider',
+        'label' => 'LLL:EXT:auth0/Resources/Private/Language/locallang.xlf:backendLogin.switch.label'
+    ];
+}


### PR DESCRIPTION
Currently, if backend login is disabled in Extension configuration, the link "Login with Auth0" is still shown and leads to "No TypoScript" error.

I assume that the link should not be shown at all, when backend login is not enabled.