### PR TITLE
Allow password changes for Auth0 users with valid session [TER-305]

### DIFF
--- a/Classes/EventListener/SudoModeRequiredEventListener.php
+++ b/Classes/EventListener/SudoModeRequiredEventListener.php
@@ -16,6 +16,7 @@ namespace Leuchtfeuer\Auth0\EventListener;
 use Leuchtfeuer\Auth0\Service\Auth0SessionValidator;
 use TYPO3\CMS\Backend\Security\SudoMode\Event\SudoModeRequiredEvent;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 /**
  * Event listener for sudo mode required events.
@@ -27,13 +28,19 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 readonly class SudoModeRequiredEventListener
 {
     public function __construct(
-        protected Auth0SessionValidator $auth0SessionValidator
+        protected Auth0SessionValidator $auth0SessionValidator,
+        protected ExtensionConfiguration $extensionConfiguration,
     ) {}
 
     public function __invoke(SudoModeRequiredEvent $event): void
     {
         if ($event->isVerificationRequired() === false) {
             // Already denied, no action needed
+            return;
+        }
+
+        if ($this->extensionConfiguration->get('auth0', 'disableSudoModeBypass')) {
+            // Sudo mode bypass disabled
             return;
         }
 

--- a/Classes/EventListener/SudoModeRequiredEventListener.php
+++ b/Classes/EventListener/SudoModeRequiredEventListener.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "Auth0" extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
+ */
+
+namespace Leuchtfeuer\Auth0\EventListener;
+
+use Leuchtfeuer\Auth0\Service\Auth0SessionValidator;
+use TYPO3\CMS\Backend\Security\SudoMode\Event\SudoModeRequiredEvent;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+
+/**
+ * Event listener for sudo mode required events.
+ *
+ * Allows Auth0-authenticated users to bypass sudo mode for all authorized operations.
+ * Authorization checks are handled by TYPO3's core authorization system.
+ */
+#[AsEventListener]
+readonly class SudoModeRequiredEventListener
+{
+    public function __construct(
+        protected Auth0SessionValidator $auth0SessionValidator
+    ) {}
+
+    public function __invoke(SudoModeRequiredEvent $event): void
+    {
+        if ($event->isVerificationRequired() === false) {
+            // Already denied, no action needed
+            return;
+        }
+
+        // Check if user is authenticated with Auth0 and has valid session
+        if ($this->auth0SessionValidator->hasValidAuth0Session()) {
+            $event->setVerificationRequired(false);
+        }
+    }
+}

--- a/Classes/Service/Auth0SessionValidator.php
+++ b/Classes/Service/Auth0SessionValidator.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "Auth0" extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
+ */
+
+namespace Leuchtfeuer\Auth0\Service;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Leuchtfeuer\Auth0\Domain\Transfer\EmAuth0Configuration;
+use Leuchtfeuer\Auth0\Factory\ApplicationFactory;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+
+/**
+ * Validates Auth0 session for sudo mode bypass.
+ *
+ * This service only checks if a user is Auth0-authenticated with a valid session.
+ * Authorization/permission checks are handled by TYPO3's core authorization system.
+ */
+class Auth0SessionValidator implements LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    public function __construct(
+        protected readonly EmAuth0Configuration $configuration
+    ) {}
+
+    /**
+     * Check if current user has a valid Auth0 session.
+     *
+     * This method only checks Auth0 authentication status. Permission checks are
+     * handled by TYPO3's authorization system - if the user doesn't have permission
+     * to perform an operation, TYPO3 will deny it before sudo mode is even checked.
+     *
+     * @return bool True if user is Auth0-authenticated with valid session, false otherwise
+     */
+    public function hasValidAuth0Session(): bool
+    {
+        // 1. Get current backend user
+        $backendUser = $this->getCurrentBackendUser();
+        if (!$backendUser instanceof BackendUserAuthentication) {
+            $this->logger?->debug('No backend user found in session.');
+            return false;
+        }
+
+        // 2. Check if current user is Auth0 user
+        $currentUserRecord = $backendUser->user;
+        if (!$this->isAuth0User($currentUserRecord)) {
+            $this->logger?->debug('Current user is not an Auth0 user.');
+            return false;
+        }
+
+        // 3. Verify Auth0 session is valid
+        $applicationUid = $this->configuration->getBackendConnection();
+        if (!$this->hasAuth0Session($applicationUid)) {
+            $this->logger?->warning('No valid Auth0 session found.');
+            return false;
+        }
+
+        $this->logger?->info(sprintf(
+            'Auth0 user %s bypassing sudo mode (valid Auth0 session).',
+            $currentUserRecord['username']
+        ));
+
+        return true;
+    }
+
+    /**
+     * Get the current backend user from global context.
+     *
+     * @return BackendUserAuthentication|null
+     */
+    protected function getCurrentBackendUser(): ?BackendUserAuthentication
+    {
+        return $GLOBALS['BE_USER'] ?? null;
+    }
+
+    /**
+     * Check if a user record belongs to an Auth0 user.
+     *
+     * @param array<string, mixed> $userRecord The user record
+     * @return bool True if user has auth0_user_id populated
+     */
+    protected function isAuth0User(array $userRecord): bool
+    {
+        return isset($userRecord['auth0_user_id']) && !empty($userRecord['auth0_user_id']);
+    }
+
+    /**
+     * Check if there is a valid Auth0 session.
+     *
+     * @param int $applicationUid The Auth0 application UID
+     * @return bool True if valid session exists
+     * @throws GuzzleException
+     */
+    protected function hasAuth0Session(int $applicationUid): bool
+    {
+        try {
+            $auth0 = ApplicationFactory::build($applicationUid, ApplicationFactory::SESSION_PREFIX_BACKEND);
+            $userInfo = $auth0->configuration()->getSessionStorage()?->get('user') ?? [];
+
+            if (!is_array($userInfo) || empty($userInfo)) {
+                $this->logger?->debug('Auth0 session storage is empty.');
+                return false;
+            }
+
+            // Check if session has required identifier (e.g., 'sub')
+            $userIdentifier = $this->configuration->getUserIdentifier();
+            if (!isset($userInfo[$userIdentifier])) {
+                $this->logger?->debug('Auth0 session missing user identifier.');
+                return false;
+            }
+
+            return true;
+        } catch (\Exception $exception) {
+            $this->logger?->error(sprintf(
+                'Error checking Auth0 session: %s',
+                $exception->getMessage()
+            ));
+            return false;
+        }
+    }
+}

--- a/Documentation/Admin/ExtensionConfiguration/Index.rst
+++ b/Documentation/Admin/ExtensionConfiguration/Index.rst
@@ -30,6 +30,7 @@ Properties
    reactivateDeletedBackendUsers_       Backend                              boolean
    softLogout_                          Backend                              boolean
    additionalAuthorizeParameters_       Backend                              string
+   disableSudoModeBypass_               Backend                              boolean
    genericCallback_                     Token                                boolean
    privateKeyFile_                      Token                                string
    publicKeyFile_                       Token                                string
@@ -127,6 +128,32 @@ additionalAuthorizeParameters
          unset
    Description
          Additional query parameters for backend authentication (e.g. `access_type=offline&connection=google-oauth2`).
+
+.. _admin-extensionConfiguration-properties-disableSudoModeBypass:
+
+disableSudoModeBypass
+---------------------
+.. container:: table-row
+
+   Property
+         disableSudoModeBypass
+   Data type
+         boolean
+   Default
+         :code:`false`
+   Description
+         Controls whether Auth0-authenticated users with a valid session can bypass TYPO3's sudo mode password
+         confirmation dialog when accessing Admin Tools modules.
+
+         When disabled (default), Auth0 users with a valid session will not be prompted for password confirmation
+         when accessing protected Admin Tools modules, providing a smoother user experience for externally
+         authenticated users.
+
+         When enabled, the standard TYPO3 sudo mode behavior is enforced, requiring password confirmation
+         regardless of Auth0 session status.
+
+         .. note::
+            This setting only applies to TYPO3 13.4.13 and higher, where sudo mode bypassing is available.
 
 .. _admin-extensionConfiguration-properties-privateKeyFile:
 

--- a/Resources/Private/Language/locallang_em.xlf
+++ b/Resources/Private/Language/locallang_em.xlf
@@ -21,6 +21,9 @@
 			<trans-unit id="backend.additional_authorize_parameters" resname="backend.additional_authorize_parameters">
 				<source><![CDATA[Additional Query Parameters: Additional query parameters for backend authentication (e.g. "access_type=offline&connection=google-oauth2")]]></source>
 			</trans-unit>
+            <trans-unit id="backend.disable_sudo_mode_bypass" resname="backend.disable_sudo_mode_bypass">
+                <source>Disable Sudo Mode Bypassing: If set, a password confirmation dialog is shown on accessing modules in the Admin Tools section</source>
+            </trans-unit>
 			<trans-unit id="frontend.enable_frontend_login" resname="frontend.enable_frontend_login">
 				<source>Frontend Log In: Enable Auth0 log in for TYPO3 frontend</source>
 			</trans-unit>

--- a/Tests/Unit/EventListener/SudoModeRequiredEventListenerTest.php
+++ b/Tests/Unit/EventListener/SudoModeRequiredEventListenerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "Auth0" extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
+ */
+
+namespace Leuchtfeuer\Auth0\Tests\Unit\EventListener;
+
+use Leuchtfeuer\Auth0\EventListener\SudoModeRequiredEventListener;
+use Leuchtfeuer\Auth0\Service\Auth0SessionValidator;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Backend\Security\SudoMode\Access\AccessClaim;
+use TYPO3\CMS\Backend\Security\SudoMode\Event\SudoModeRequiredEvent;
+
+/**
+ * Test case for SudoModeRequiredEventListener
+ */
+class SudoModeRequiredEventListenerTest extends TestCase
+{
+    protected SudoModeRequiredEventListener $subject;
+    protected Auth0SessionValidator $sessionValidator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sessionValidator = $this->createMock(Auth0SessionValidator::class);
+        $this->subject = new SudoModeRequiredEventListener($this->sessionValidator);
+    }
+
+    /**
+     * @test
+     */
+    public function testBypassesWhenValidAuth0Session(): void
+    {
+        // Create real event with mocked claim
+        $claim = $this->createMock(AccessClaim::class);
+        $event = new SudoModeRequiredEvent($claim);
+
+        // Configure session validator to allow bypass
+        $this->sessionValidator->method('hasValidAuth0Session')->willReturn(true);
+
+        // Invoke event listener
+        ($this->subject)($event);
+
+        // Verify sudo mode was bypassed (state verification instead of mock expectation)
+        self::assertFalse($event->isVerificationRequired());
+    }
+
+    /**
+     * @test
+     */
+    public function testDoesNotBypassWhenNoValidSession(): void
+    {
+        // Create real event with mocked claim
+        $claim = $this->createMock(AccessClaim::class);
+        $event = new SudoModeRequiredEvent($claim);
+
+        // Configure session validator to reject
+        $this->sessionValidator->method('hasValidAuth0Session')->willReturn(false);
+
+        // Invoke event listener
+        ($this->subject)($event);
+
+        // Verify sudo mode was NOT bypassed (still required)
+        self::assertTrue($event->isVerificationRequired());
+    }
+
+    /**
+     * @test
+     */
+    public function testDoesNothingWhenVerificationAlreadyDenied(): void
+    {
+        // Create real event with verification already denied
+        $claim = $this->createMock(AccessClaim::class);
+        $event = new SudoModeRequiredEvent($claim);
+        $event->setVerificationRequired(false); // Pre-set to denied
+
+        // Expect session validator NOT to be called (early return in listener)
+        $this->sessionValidator->expects(self::never())
+            ->method('hasValidAuth0Session');
+
+        // Invoke event listener
+        ($this->subject)($event);
+
+        // Verify verification requirement unchanged (still false)
+        self::assertFalse($event->isVerificationRequired());
+    }
+}

--- a/Tests/Unit/Service/Auth0SessionValidatorTest.php
+++ b/Tests/Unit/Service/Auth0SessionValidatorTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "Auth0" extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
+ */
+
+namespace Leuchtfeuer\Auth0\Tests\Unit\Service;
+
+use Leuchtfeuer\Auth0\Domain\Transfer\EmAuth0Configuration;
+use Leuchtfeuer\Auth0\Service\Auth0SessionValidator;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+
+/**
+ * Test case for Auth0SessionValidator
+ *
+ * Note: Some test methods require functional testing with real TYPO3 environment
+ * due to ApplicationFactory static calls and $GLOBALS['BE_USER'] dependency.
+ */
+class Auth0SessionValidatorTest extends TestCase
+{
+    protected Auth0SessionValidator $subject;
+    protected EmAuth0Configuration $configuration;
+    protected ?BackendUserAuthentication $originalBackendUser = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configuration = $this->createMock(EmAuth0Configuration::class);
+
+        $this->subject = new Auth0SessionValidator($this->configuration);
+
+        // Store original BE_USER if exists
+        $this->originalBackendUser = $GLOBALS['BE_USER'] ?? null;
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore original BE_USER
+        if ($this->originalBackendUser !== null) {
+            $GLOBALS['BE_USER'] = $this->originalBackendUser;
+        } else {
+            unset($GLOBALS['BE_USER']);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     */
+    public function testReturnsFalseWhenNoBackendUser(): void
+    {
+        unset($GLOBALS['BE_USER']);
+
+        $result = $this->subject->hasValidAuth0Session();
+
+        self::assertFalse($result);
+    }
+
+    /**
+     * @test
+     */
+    public function testReturnsFalseWhenUserNotAuth0User(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = [
+            'uid' => 1,
+            'username' => 'admin',
+            'auth0_user_id' => '', // Empty Auth0 ID
+        ];
+
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $result = $this->subject->hasValidAuth0Session();
+
+        self::assertFalse($result);
+    }
+
+    /**
+     * @test
+     */
+    public function testReturnsFalseWhenAuth0UserIdIsNull(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = [
+            'uid' => 1,
+            'username' => 'regular_user',
+            // auth0_user_id key doesn't exist
+        ];
+
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $result = $this->subject->hasValidAuth0Session();
+
+        self::assertFalse($result);
+    }
+
+    /**
+     * @test
+     */
+    public function testReturnsTrueWhenAuth0SessionIsValid(): void
+    {
+        // Setup backend user with Auth0 authentication
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = [
+            'uid' => 2,
+            'username' => 'auth0_user',
+            'auth0_user_id' => 'auth0|123456789',
+        ];
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        // Create partial mock to stub the hasAuth0Session method
+        // This avoids calling ApplicationFactory::build() which requires functional environment
+        $validatorMock = $this->getMockBuilder(Auth0SessionValidator::class)
+            ->setConstructorArgs([$this->configuration])
+            ->onlyMethods(['hasAuth0Session'])
+            ->getMock();
+
+        // Stub hasAuth0Session to return true (simulating valid Auth0 session)
+        $validatorMock->expects(self::once())
+            ->method('hasAuth0Session')
+            ->willReturn(true);
+
+        // Call the method
+        $result = $validatorMock->hasValidAuth0Session();
+
+        // Verify returns true when Auth0 session is valid
+        self::assertTrue($result);
+    }
+
+    /**
+     * @test
+     */
+    public function testReturnsFalseWhenAuth0SessionCheckFails(): void
+    {
+        // Setup backend user with Auth0 authentication
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = [
+            'uid' => 3,
+            'username' => 'auth0_session_fail_user',
+            'auth0_user_id' => 'auth0|987654321',
+        ];
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        // Create partial mock to stub the hasAuth0Session method
+        $validatorMock = $this->getMockBuilder(Auth0SessionValidator::class)
+            ->setConstructorArgs([$this->configuration])
+            ->onlyMethods(['hasAuth0Session'])
+            ->getMock();
+
+        // Stub hasAuth0Session to return false (simulating ApplicationFactory failure or invalid session)
+        // In the real implementation, exceptions are caught and false is returned
+        $validatorMock->expects(self::once())
+            ->method('hasAuth0Session')
+            ->willReturn(false);
+
+        // Call the method
+        $result = $validatorMock->hasValidAuth0Session();
+
+        // Verify returns false when Auth0 session check fails
+        self::assertFalse($result);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -44,12 +44,12 @@
         "symfony/property-access": "^6.2 || ^7.1.4",
         "symfony/property-info": "^6.3 || ^7.1",
         "symfony/serializer": "^6.4 || ^7.0",
-        "typo3/cms-backend": "^13.4",
-        "typo3/cms-core": "^13.4",
-        "typo3/cms-extbase": "^13.4",
-        "typo3/cms-extensionmanager": "^13.4",
-        "typo3/cms-fluid": "^13.4",
-        "typo3/cms-frontend": "^13.4"
+        "typo3/cms-backend": "^13.4.13",
+        "typo3/cms-core": "^13.4.13",
+        "typo3/cms-extbase": "^13.4.13",
+        "typo3/cms-extensionmanager": "^13.4.13",
+        "typo3/cms-fluid": "^13.4.13",
+        "typo3/cms-frontend": "^13.4.13"
     },
     "suggest": {
         "typo3/cms-scheduler": "TYPO3 Scheduler"

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -16,6 +16,9 @@ softLogout = 0
 # cat=Backend/60; type=string; label=LLL:EXT:auth0/Resources/Private/Language/locallang_em.xlf:backend.additional_authorize_parameters
 additionalAuthorizeParameters =
 
+# cat=Backend/60; type=boolean; label=LLL:EXT:auth0/Resources/Private/Language/locallang_em.xlf:backend.disable_sudo_mode_bypass
+disableSudoModeBypass = 0
+
 # cat=Token/20; type=string; label=LLL:EXT:auth0/Resources/Private/Language/locallang_em.xlf:token.private_key_file
 privateKeyFile =
 


### PR DESCRIPTION
This PR implements the SudoModeRequiredEvent handler to allow Auth0-authenticated users to change their password without entering their current password when they have a valid Auth0 session.

Changes:

- Added SudoModeRequiredEventListener to bypass sudo mode for Auth0 users
- Implemented Auth0SessionValidator service to validate Auth0 sessions
- Added comprehensive unit tests for both components

The event listener checks if the current user is Auth0-authenticated and has a valid session. If both conditions are met, sudo mode verification is bypassed, allowing password changes without entering the current (non-existent) password.