### PR TITLE
Update test for sudo mode listener with extension configuration [TER-305]

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -12,7 +12,7 @@ This file is part of the "Auth0" extension for TYPO3 CMS.
 For the full copyright and license information, please read the
 LICENSE.txt file that was distributed with this source code.
 
-Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+(c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
 COMMENT;
 
 $finder = (new PhpCsFixer\Finder())

--- a/Classes/Configuration/Auth0Configuration.php
+++ b/Classes/Configuration/Auth0Configuration.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Configuration;

--- a/Tests/Unit/EventListener/SudoModeRequiredEventListenerTest.php
+++ b/Tests/Unit/EventListener/SudoModeRequiredEventListenerTest.php
@@ -18,6 +18,7 @@ use Leuchtfeuer\Auth0\Service\Auth0SessionValidator;
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Backend\Security\SudoMode\Access\AccessClaim;
 use TYPO3\CMS\Backend\Security\SudoMode\Event\SudoModeRequiredEvent;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 /**
  * Test case for SudoModeRequiredEventListener
@@ -26,13 +27,24 @@ class SudoModeRequiredEventListenerTest extends TestCase
 {
     protected SudoModeRequiredEventListener $subject;
     protected Auth0SessionValidator $sessionValidator;
+    protected ExtensionConfiguration $extensionConfiguration;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->sessionValidator = $this->createMock(Auth0SessionValidator::class);
-        $this->subject = new SudoModeRequiredEventListener($this->sessionValidator);
+        $this->extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+
+        // Configure extension configuration to not disable sudo mode bypass
+        $this->extensionConfiguration->method('get')
+            ->with('auth0', 'disableSudoModeBypass')
+            ->willReturn(false);
+
+        $this->subject = new SudoModeRequiredEventListener(
+            $this->sessionValidator,
+            $this->extensionConfiguration
+        );
     }
 
     /**


### PR DESCRIPTION
Updated SudoModeRequiredEventListenerTest to accommodate the new ExtensionConfiguration dependency. The test now properly mocks the extension configuration and sets it to not disable sudo mode bypass, ensuring the listener behavior can be properly tested.