### PR TITLE
Allow password changes for Auth0 users with valid session [TER-305]

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -12,7 +12,7 @@ This file is part of the "Auth0" extension for TYPO3 CMS.
 For the full copyright and license information, please read the
 LICENSE.txt file that was distributed with this source code.
 
-Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+(c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
 COMMENT;
 
 $finder = (new PhpCsFixer\Finder())

--- a/Classes/Command/CleanUpCommand.php
+++ b/Classes/Command/CleanUpCommand.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Command;

--- a/Classes/Controller/ApplicationController.php
+++ b/Classes/Controller/ApplicationController.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Controller;

--- a/Classes/Controller/BackendController.php
+++ b/Classes/Controller/BackendController.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Controller;

--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Controller;

--- a/Classes/Controller/PropertyController.php
+++ b/Classes/Controller/PropertyController.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Controller;

--- a/Classes/Controller/RoleController.php
+++ b/Classes/Controller/RoleController.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Controller;

--- a/Classes/Domain/Model/Application.php
+++ b/Classes/Domain/Model/Application.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Domain\Model;

--- a/Classes/Domain/Repository/ApplicationRepository.php
+++ b/Classes/Domain/Repository/ApplicationRepository.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Domain\Repository;

--- a/Classes/Domain/Repository/FrontendUserRepository.php
+++ b/Classes/Domain/Repository/FrontendUserRepository.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Domain\Repository;

--- a/Classes/Domain/Repository/UserGroup/AbstractUserGroupRepository.php
+++ b/Classes/Domain/Repository/UserGroup/AbstractUserGroupRepository.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Domain\Repository\UserGroup;

--- a/Classes/Domain/Repository/UserGroup/BackendUserGroupRepository.php
+++ b/Classes/Domain/Repository/UserGroup/BackendUserGroupRepository.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Domain\Repository\UserGroup;

--- a/Classes/Domain/Repository/UserGroup/FrontendUserGroupRepository.php
+++ b/Classes/Domain/Repository/UserGroup/FrontendUserGroupRepository.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Domain\Repository\UserGroup;

--- a/Classes/Domain/Repository/UserRepository.php
+++ b/Classes/Domain/Repository/UserRepository.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Domain\Repository;

--- a/Classes/Domain/Transfer/EmAuth0Configuration.php
+++ b/Classes/Domain/Transfer/EmAuth0Configuration.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Domain\Transfer;

--- a/Classes/ErrorCode.php
+++ b/Classes/ErrorCode.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0;

--- a/Classes/Event/RedirectPreProcessingEvent.php
+++ b/Classes/Event/RedirectPreProcessingEvent.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Event;

--- a/Classes/EventListener/AfterPackageActivation.php
+++ b/Classes/EventListener/AfterPackageActivation.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\EventListener;

--- a/Classes/EventListener/SudoModeRequiredEventListener.php
+++ b/Classes/EventListener/SudoModeRequiredEventListener.php
@@ -16,6 +16,7 @@ namespace Leuchtfeuer\Auth0\EventListener;
 use Leuchtfeuer\Auth0\Service\Auth0SessionValidator;
 use TYPO3\CMS\Backend\Security\SudoMode\Event\SudoModeRequiredEvent;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 /**
  * Event listener for sudo mode required events.
@@ -27,13 +28,19 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 readonly class SudoModeRequiredEventListener
 {
     public function __construct(
-        protected Auth0SessionValidator $auth0SessionValidator
+        protected Auth0SessionValidator $auth0SessionValidator,
+        protected ExtensionConfiguration $extensionConfiguration,
     ) {}
 
     public function __invoke(SudoModeRequiredEvent $event): void
     {
         if ($event->isVerificationRequired() === false) {
             // Already denied, no action needed
+            return;
+        }
+
+        if ($this->extensionConfiguration->get('auth0', 'disableSudoModeBypass')) {
+            // Sudo mode bypass disabled
             return;
         }
 

--- a/Classes/EventListener/SudoModeRequiredEventListener.php
+++ b/Classes/EventListener/SudoModeRequiredEventListener.php
@@ -25,10 +25,15 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
  */
 class SudoModeRequiredEventListener
 {
+    protected Auth0SessionValidator $auth0SessionValidator;
+    protected ExtensionConfiguration $extensionConfiguration;
+
     public function __construct(
-        protected Auth0SessionValidator $auth0SessionValidator,
-        protected ExtensionConfiguration $extensionConfiguration,
+        Auth0SessionValidator $auth0SessionValidator,
+        ExtensionConfiguration $extensionConfiguration,
     ) {
+        $this->auth0SessionValidator = $auth0SessionValidator;
+        $this->extensionConfiguration = $extensionConfiguration;
     }
 
     public function __invoke(SudoModeRequiredEvent $event): void

--- a/Classes/EventListener/SudoModeRequiredEventListener.php
+++ b/Classes/EventListener/SudoModeRequiredEventListener.php
@@ -25,7 +25,7 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
  * Authorization checks are handled by TYPO3's core authorization system.
  */
 #[AsEventListener]
-readonly class SudoModeRequiredEventListener
+class SudoModeRequiredEventListener
 {
     public function __construct(
         protected Auth0SessionValidator $auth0SessionValidator,

--- a/Classes/EventListener/SudoModeRequiredEventListener.php
+++ b/Classes/EventListener/SudoModeRequiredEventListener.php
@@ -30,7 +30,7 @@ class SudoModeRequiredEventListener
 
     public function __construct(
         Auth0SessionValidator $auth0SessionValidator,
-        ExtensionConfiguration $extensionConfiguration,
+        ExtensionConfiguration $extensionConfiguration
     ) {
         $this->auth0SessionValidator = $auth0SessionValidator;
         $this->extensionConfiguration = $extensionConfiguration;

--- a/Classes/EventListener/SudoModeRequiredEventListener.php
+++ b/Classes/EventListener/SudoModeRequiredEventListener.php
@@ -28,7 +28,8 @@ class SudoModeRequiredEventListener
     public function __construct(
         protected Auth0SessionValidator $auth0SessionValidator,
         protected ExtensionConfiguration $extensionConfiguration,
-    ) {}
+    ) {
+    }
 
     public function __invoke(SudoModeRequiredEvent $event): void
     {

--- a/Classes/EventListener/SudoModeRequiredEventListener.php
+++ b/Classes/EventListener/SudoModeRequiredEventListener.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "Auth0" extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
+ */
+
+namespace Leuchtfeuer\Auth0\EventListener;
+
+use Leuchtfeuer\Auth0\Service\Auth0SessionValidator;
+use TYPO3\CMS\Backend\Security\SudoMode\Event\SudoModeRequiredEvent;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+
+/**
+ * Event listener for sudo mode required events.
+ *
+ * Allows Auth0-authenticated users to bypass sudo mode for all authorized operations.
+ * Authorization checks are handled by TYPO3's core authorization system.
+ */
+#[AsEventListener]
+readonly class SudoModeRequiredEventListener
+{
+    public function __construct(
+        protected Auth0SessionValidator $auth0SessionValidator
+    ) {}
+
+    public function __invoke(SudoModeRequiredEvent $event): void
+    {
+        if ($event->isVerificationRequired() === false) {
+            // Already denied, no action needed
+            return;
+        }
+
+        // Check if user is authenticated with Auth0 and has valid session
+        if ($this->auth0SessionValidator->hasValidAuth0Session()) {
+            $event->setVerificationRequired(false);
+        }
+    }
+}

--- a/Classes/EventListener/SudoModeRequiredEventListener.php
+++ b/Classes/EventListener/SudoModeRequiredEventListener.php
@@ -15,7 +15,6 @@ namespace Leuchtfeuer\Auth0\EventListener;
 
 use Leuchtfeuer\Auth0\Service\Auth0SessionValidator;
 use TYPO3\CMS\Backend\Security\SudoMode\Event\SudoModeRequiredEvent;
-use TYPO3\CMS\Core\Attribute\AsEventListener;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 /**
@@ -24,7 +23,6 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
  * Allows Auth0-authenticated users to bypass sudo mode for all authorized operations.
  * Authorization checks are handled by TYPO3's core authorization system.
  */
-#[AsEventListener]
 class SudoModeRequiredEventListener
 {
     public function __construct(

--- a/Classes/Exception/TokenException.php
+++ b/Classes/Exception/TokenException.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Exception;

--- a/Classes/Exception/UnknownErrorCodeException.php
+++ b/Classes/Exception/UnknownErrorCodeException.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Exception;

--- a/Classes/Factory/ApplicationFactory.php
+++ b/Classes/Factory/ApplicationFactory.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Factory;

--- a/Classes/Factory/ConfigurationFactory.php
+++ b/Classes/Factory/ConfigurationFactory.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Factory;

--- a/Classes/Hooks/PageLayoutViewHook.php
+++ b/Classes/Hooks/PageLayoutViewHook.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Hooks;

--- a/Classes/Hooks/SingleSignOutHook.php
+++ b/Classes/Hooks/SingleSignOutHook.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Hooks;

--- a/Classes/LoginProvider/Auth0Provider.php
+++ b/Classes/LoginProvider/Auth0Provider.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\LoginProvider;

--- a/Classes/Middleware/CallbackMiddleware.php
+++ b/Classes/Middleware/CallbackMiddleware.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Middleware;

--- a/Classes/Service/Auth0SessionValidator.php
+++ b/Classes/Service/Auth0SessionValidator.php
@@ -30,9 +30,12 @@ class Auth0SessionValidator implements LoggerAwareInterface
 {
     use LoggerAwareTrait;
 
+    protected EmAuth0Configuration $configuration;
+
     public function __construct(
-        protected readonly EmAuth0Configuration $configuration
+        EmAuth0Configuration $configuration
     ) {
+        $this->configuration = $configuration;
     }
 
     /**

--- a/Classes/Service/Auth0SessionValidator.php
+++ b/Classes/Service/Auth0SessionValidator.php
@@ -119,7 +119,10 @@ class Auth0SessionValidator implements LoggerAwareInterface
     {
         try {
             $auth0 = ApplicationFactory::build($applicationUid, ApplicationFactory::SESSION_PREFIX_BACKEND);
-            $userInfo = $auth0->configuration()->getSessionStorage()?->get('user') ?? [];
+            $userInfo = [];
+            if ($auth0->configuration()->getSessionStorage() !== null) {
+                $userInfo = $auth0->configuration()->getSessionStorage()->get('user') ?? [];
+            }
 
             if (!is_array($userInfo) || empty($userInfo)) {
                 if ($this->logger instanceof LoggerInterface) {

--- a/Classes/Service/Auth0SessionValidator.php
+++ b/Classes/Service/Auth0SessionValidator.php
@@ -32,7 +32,8 @@ class Auth0SessionValidator implements LoggerAwareInterface
 
     public function __construct(
         protected readonly EmAuth0Configuration $configuration
-    ) {}
+    ) {
+    }
 
     /**
      * Check if current user has a valid Auth0 session.

--- a/Classes/Service/Auth0SessionValidator.php
+++ b/Classes/Service/Auth0SessionValidator.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "Auth0" extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
+ */
+
+namespace Leuchtfeuer\Auth0\Service;
+
+use GuzzleHttp\Exception\GuzzleException;
+use Leuchtfeuer\Auth0\Domain\Transfer\EmAuth0Configuration;
+use Leuchtfeuer\Auth0\Factory\ApplicationFactory;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+
+/**
+ * Validates Auth0 session for sudo mode bypass.
+ *
+ * This service only checks if a user is Auth0-authenticated with a valid session.
+ * Authorization/permission checks are handled by TYPO3's core authorization system.
+ */
+class Auth0SessionValidator implements LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    public function __construct(
+        protected readonly EmAuth0Configuration $configuration
+    ) {}
+
+    /**
+     * Check if current user has a valid Auth0 session.
+     *
+     * This method only checks Auth0 authentication status. Permission checks are
+     * handled by TYPO3's authorization system - if the user doesn't have permission
+     * to perform an operation, TYPO3 will deny it before sudo mode is even checked.
+     *
+     * @return bool True if user is Auth0-authenticated with valid session, false otherwise
+     */
+    public function hasValidAuth0Session(): bool
+    {
+        // 1. Get current backend user
+        $backendUser = $this->getCurrentBackendUser();
+        if (!$backendUser instanceof BackendUserAuthentication) {
+            $this->logger?->debug('No backend user found in session.');
+            return false;
+        }
+
+        // 2. Check if current user is Auth0 user
+        $currentUserRecord = $backendUser->user;
+        if (!$this->isAuth0User($currentUserRecord)) {
+            $this->logger?->debug('Current user is not an Auth0 user.');
+            return false;
+        }
+
+        // 3. Verify Auth0 session is valid
+        $applicationUid = $this->configuration->getBackendConnection();
+        if (!$this->hasAuth0Session($applicationUid)) {
+            $this->logger?->warning('No valid Auth0 session found.');
+            return false;
+        }
+
+        $this->logger?->info(sprintf(
+            'Auth0 user %s bypassing sudo mode (valid Auth0 session).',
+            $currentUserRecord['username']
+        ));
+
+        return true;
+    }
+
+    /**
+     * Get the current backend user from global context.
+     *
+     * @return BackendUserAuthentication|null
+     */
+    protected function getCurrentBackendUser(): ?BackendUserAuthentication
+    {
+        return $GLOBALS['BE_USER'] ?? null;
+    }
+
+    /**
+     * Check if a user record belongs to an Auth0 user.
+     *
+     * @param array<string, mixed> $userRecord The user record
+     * @return bool True if user has auth0_user_id populated
+     */
+    protected function isAuth0User(array $userRecord): bool
+    {
+        return isset($userRecord['auth0_user_id']) && !empty($userRecord['auth0_user_id']);
+    }
+
+    /**
+     * Check if there is a valid Auth0 session.
+     *
+     * @param int $applicationUid The Auth0 application UID
+     * @return bool True if valid session exists
+     * @throws GuzzleException
+     */
+    protected function hasAuth0Session(int $applicationUid): bool
+    {
+        try {
+            $auth0 = ApplicationFactory::build($applicationUid, ApplicationFactory::SESSION_PREFIX_BACKEND);
+            $userInfo = $auth0->configuration()->getSessionStorage()?->get('user') ?? [];
+
+            if (!is_array($userInfo) || empty($userInfo)) {
+                $this->logger?->debug('Auth0 session storage is empty.');
+                return false;
+            }
+
+            // Check if session has required identifier (e.g., 'sub')
+            $userIdentifier = $this->configuration->getUserIdentifier();
+            if (!isset($userInfo[$userIdentifier])) {
+                $this->logger?->debug('Auth0 session missing user identifier.');
+                return false;
+            }
+
+            return true;
+        } catch (\Exception $exception) {
+            $this->logger?->error(sprintf(
+                'Error checking Auth0 session: %s',
+                $exception->getMessage()
+            ));
+            return false;
+        }
+    }
+}

--- a/Classes/Service/AuthenticationService.php
+++ b/Classes/Service/AuthenticationService.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Service;

--- a/Classes/Service/RedirectService.php
+++ b/Classes/Service/RedirectService.php
@@ -266,7 +266,8 @@ class RedirectService implements LoggerAwareInterface
         $parsedUrl = @parse_url($url);
         if ($parsedUrl !== false && !isset($parsedUrl['scheme']) && !isset($parsedUrl['host'])) {
             // If the relative URL starts with a slash, we need to check if it's within the current site path
-            return $parsedUrl['path'][0] !== '/' || \str_starts_with($parsedUrl['path'], GeneralUtility::getIndpEnv('TYPO3_SITE_PATH'));
+            $sitePath = GeneralUtility::getIndpEnv('TYPO3_SITE_PATH');
+            return $parsedUrl['path'][0] !== '/' || strpos($parsedUrl['path'], $sitePath) === 0;
         }
 
         return false;
@@ -284,8 +285,8 @@ class RedirectService implements LoggerAwareInterface
         $urlWithoutSchema = preg_replace('#^https?://#', '', $url);
         $siteUrlWithoutSchema = preg_replace('#^https?://#', '', GeneralUtility::getIndpEnv('TYPO3_SITE_URL'));
 
-        return \str_starts_with($urlWithoutSchema . '/', GeneralUtility::getIndpEnv('HTTP_HOST') . '/')
-            && \str_starts_with($urlWithoutSchema, $siteUrlWithoutSchema);
+        return strpos($urlWithoutSchema . '/', GeneralUtility::getIndpEnv('HTTP_HOST') . '/') === 0
+            && strpos($urlWithoutSchema, $siteUrlWithoutSchema) === 0;
     }
 
     /**
@@ -315,7 +316,7 @@ class RedirectService implements LoggerAwareInterface
                     foreach ($localDomains as $localDomain) {
                         // strip trailing slashes (if given)
                         $domainName = rtrim($localDomain['domainName'], '/');
-                        if (\str_starts_with($host . $path . '/', $domainName . '/')) {
+                        if (strpos($host . $path . '/', $domainName . '/') === 0) {
                             return true;
                         }
                     }

--- a/Classes/Service/RedirectService.php
+++ b/Classes/Service/RedirectService.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Service;

--- a/Classes/Utility/Database/UpdateUtility.php
+++ b/Classes/Utility/Database/UpdateUtility.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Utility\Database;

--- a/Classes/Utility/ModeUtility.php
+++ b/Classes/Utility/ModeUtility.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Utility;

--- a/Classes/Utility/ParametersUtility.php
+++ b/Classes/Utility/ParametersUtility.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Utility;

--- a/Classes/Utility/ParseFuncUtility.php
+++ b/Classes/Utility/ParseFuncUtility.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Utility;

--- a/Classes/Utility/RoutingUtility.php
+++ b/Classes/Utility/RoutingUtility.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Utility;

--- a/Classes/Utility/TcaUtility.php
+++ b/Classes/Utility/TcaUtility.php
@@ -6,7 +6,7 @@
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Utility;

--- a/Classes/Utility/TokenUtility.php
+++ b/Classes/Utility/TokenUtility.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Utility;

--- a/Classes/Utility/UserUtility.php
+++ b/Classes/Utility/UserUtility.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please read the
  * LICENSE.txt file that was distributed with this source code.
  *
- * Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
  */
 
 namespace Leuchtfeuer\Auth0\Utility;

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -18,3 +18,9 @@ services:
       - name: event.listener
         identifier: auth0AfterPackageActivationEvent
         event: TYPO3\CMS\Core\Package\Event\AfterPackageActivationEvent
+
+  Leuchtfeuer\Auth0\EventListener\SudoModeRequiredEventListener:
+    tags:
+      - name: event.listener
+        identifier: auth0SudoModeRequiredEvent
+        event: TYPO3\CMS\Backend\Security\SudoMode\Event\SudoModeRequiredEvent

--- a/Documentation/Admin/ExtensionConfiguration/Index.rst
+++ b/Documentation/Admin/ExtensionConfiguration/Index.rst
@@ -30,6 +30,7 @@ Properties
    reactivateDeletedBackendUsers_       Backend                              boolean
    softLogout_                          Backend                              boolean
    additionalAuthorizeParameters_       Backend                              string
+   disableSudoModeBypass_               Backend                              boolean
    enableFrontendLogin_                 Frontend                             boolean
    userStoragePage_                     Frontend                             positive integer
    reactivateDisabledFrontendUsers_     Frontend                             boolean
@@ -131,6 +132,32 @@ additionalAuthorizeParameters
          unset
    Description
          Additional query parameters for backend authentication (e.g. `access_type=offline&connection=google-oauth2`).
+
+.. _admin-extensionConfiguration-properties-disableSudoModeBypass:
+
+disableSudoModeBypass
+---------------------
+.. container:: table-row
+
+   Property
+         disableSudoModeBypass
+   Data type
+         boolean
+   Default
+         :code:`false`
+   Description
+         Controls whether Auth0-authenticated users with a valid session can bypass TYPO3's sudo mode password
+         confirmation dialog when accessing Admin Tools modules.
+
+         When disabled (default), Auth0 users with a valid session will not be prompted for password confirmation
+         when accessing protected Admin Tools modules, providing a smoother user experience for externally
+         authenticated users.
+
+         When enabled, the standard TYPO3 sudo mode behavior is enforced, requiring password confirmation
+         regardless of Auth0 session status.
+
+         .. note::
+            This setting only applies to TYPO3 13.4.13 and higher, where sudo mode bypassing is available.
 
 .. _admin-extensionConfiguration-properties-enableFrontendLogin:
 

--- a/Documentation/Admin/ExtensionConfiguration/Index.rst
+++ b/Documentation/Admin/ExtensionConfiguration/Index.rst
@@ -157,7 +157,7 @@ disableSudoModeBypass
          regardless of Auth0 session status.
 
          .. note::
-            This setting only applies to TYPO3 13.4.13 and higher, where sudo mode bypassing is available.
+            This setting only applies to TYPO3 12.4.32 and higher, where sudo mode bypassing is available.
 
 .. _admin-extensionConfiguration-properties-enableFrontendLogin:
 

--- a/Resources/Private/Language/locallang_em.xlf
+++ b/Resources/Private/Language/locallang_em.xlf
@@ -21,6 +21,9 @@
 			<trans-unit id="backend.additional_authorize_parameters" resname="backend.additional_authorize_parameters">
 				<source><![CDATA[Additional Query Parameters: Additional query parameters for backend authentication (e.g. "access_type=offline&connection=google-oauth2")]]></source>
 			</trans-unit>
+            <trans-unit id="backend.disable_sudo_mode_bypass" resname="backend.disable_sudo_mode_bypass">
+                <source>Disable Sudo Mode Bypassing: If set, a password confirmation dialog is shown on accessing modules in the Admin Tools section</source>
+            </trans-unit>
 			<trans-unit id="frontend.enable_frontend_login" resname="frontend.enable_frontend_login">
 				<source>Frontend Log In: Enable Auth0 log in for TYPO3 frontend</source>
 			</trans-unit>

--- a/Tests/Unit/EventListener/SudoModeRequiredEventListenerTest.php
+++ b/Tests/Unit/EventListener/SudoModeRequiredEventListenerTest.php
@@ -18,6 +18,7 @@ use Leuchtfeuer\Auth0\Service\Auth0SessionValidator;
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Backend\Security\SudoMode\Access\AccessClaim;
 use TYPO3\CMS\Backend\Security\SudoMode\Event\SudoModeRequiredEvent;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 /**
  * Test case for SudoModeRequiredEventListener
@@ -26,13 +27,24 @@ class SudoModeRequiredEventListenerTest extends TestCase
 {
     protected SudoModeRequiredEventListener $subject;
     protected Auth0SessionValidator $sessionValidator;
+    protected ExtensionConfiguration $extensionConfiguration;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->sessionValidator = $this->createMock(Auth0SessionValidator::class);
-        $this->subject = new SudoModeRequiredEventListener($this->sessionValidator);
+        $this->extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+
+        // Configure extension configuration to not disable sudo mode bypass
+        $this->extensionConfiguration->method('get')
+            ->with('auth0', 'disableSudoModeBypass')
+            ->willReturn(false);
+
+        $this->subject = new SudoModeRequiredEventListener(
+            $this->sessionValidator,
+            $this->extensionConfiguration
+        );
     }
 
     /**

--- a/Tests/Unit/EventListener/SudoModeRequiredEventListenerTest.php
+++ b/Tests/Unit/EventListener/SudoModeRequiredEventListenerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "Auth0" extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
+ */
+
+namespace Leuchtfeuer\Auth0\Tests\Unit\EventListener;
+
+use Leuchtfeuer\Auth0\EventListener\SudoModeRequiredEventListener;
+use Leuchtfeuer\Auth0\Service\Auth0SessionValidator;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Backend\Security\SudoMode\Access\AccessClaim;
+use TYPO3\CMS\Backend\Security\SudoMode\Event\SudoModeRequiredEvent;
+
+/**
+ * Test case for SudoModeRequiredEventListener
+ */
+class SudoModeRequiredEventListenerTest extends TestCase
+{
+    protected SudoModeRequiredEventListener $subject;
+    protected Auth0SessionValidator $sessionValidator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sessionValidator = $this->createMock(Auth0SessionValidator::class);
+        $this->subject = new SudoModeRequiredEventListener($this->sessionValidator);
+    }
+
+    /**
+     * @test
+     */
+    public function testBypassesWhenValidAuth0Session(): void
+    {
+        // Create real event with mocked claim
+        $claim = $this->createMock(AccessClaim::class);
+        $event = new SudoModeRequiredEvent($claim);
+
+        // Configure session validator to allow bypass
+        $this->sessionValidator->method('hasValidAuth0Session')->willReturn(true);
+
+        // Invoke event listener
+        ($this->subject)($event);
+
+        // Verify sudo mode was bypassed (state verification instead of mock expectation)
+        self::assertFalse($event->isVerificationRequired());
+    }
+
+    /**
+     * @test
+     */
+    public function testDoesNotBypassWhenNoValidSession(): void
+    {
+        // Create real event with mocked claim
+        $claim = $this->createMock(AccessClaim::class);
+        $event = new SudoModeRequiredEvent($claim);
+
+        // Configure session validator to reject
+        $this->sessionValidator->method('hasValidAuth0Session')->willReturn(false);
+
+        // Invoke event listener
+        ($this->subject)($event);
+
+        // Verify sudo mode was NOT bypassed (still required)
+        self::assertTrue($event->isVerificationRequired());
+    }
+
+    /**
+     * @test
+     */
+    public function testDoesNothingWhenVerificationAlreadyDenied(): void
+    {
+        // Create real event with verification already denied
+        $claim = $this->createMock(AccessClaim::class);
+        $event = new SudoModeRequiredEvent($claim);
+        $event->setVerificationRequired(false); // Pre-set to denied
+
+        // Expect session validator NOT to be called (early return in listener)
+        $this->sessionValidator->expects(self::never())
+            ->method('hasValidAuth0Session');
+
+        // Invoke event listener
+        ($this->subject)($event);
+
+        // Verify verification requirement unchanged (still false)
+        self::assertFalse($event->isVerificationRequired());
+    }
+}

--- a/Tests/Unit/Service/Auth0SessionValidatorTest.php
+++ b/Tests/Unit/Service/Auth0SessionValidatorTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "Auth0" extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
+ */
+
+namespace Leuchtfeuer\Auth0\Tests\Unit\Service;
+
+use Leuchtfeuer\Auth0\Domain\Transfer\EmAuth0Configuration;
+use Leuchtfeuer\Auth0\Service\Auth0SessionValidator;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+
+/**
+ * Test case for Auth0SessionValidator
+ *
+ * Note: Some test methods require functional testing with real TYPO3 environment
+ * due to ApplicationFactory static calls and $GLOBALS['BE_USER'] dependency.
+ */
+class Auth0SessionValidatorTest extends TestCase
+{
+    protected Auth0SessionValidator $subject;
+    protected EmAuth0Configuration $configuration;
+    protected ?BackendUserAuthentication $originalBackendUser = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configuration = $this->createMock(EmAuth0Configuration::class);
+
+        $this->subject = new Auth0SessionValidator($this->configuration);
+
+        // Store original BE_USER if exists
+        $this->originalBackendUser = $GLOBALS['BE_USER'] ?? null;
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore original BE_USER
+        if ($this->originalBackendUser !== null) {
+            $GLOBALS['BE_USER'] = $this->originalBackendUser;
+        } else {
+            unset($GLOBALS['BE_USER']);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     */
+    public function testReturnsFalseWhenNoBackendUser(): void
+    {
+        unset($GLOBALS['BE_USER']);
+
+        $result = $this->subject->hasValidAuth0Session();
+
+        self::assertFalse($result);
+    }
+
+    /**
+     * @test
+     */
+    public function testReturnsFalseWhenUserNotAuth0User(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = [
+            'uid' => 1,
+            'username' => 'admin',
+            'auth0_user_id' => '', // Empty Auth0 ID
+        ];
+
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $result = $this->subject->hasValidAuth0Session();
+
+        self::assertFalse($result);
+    }
+
+    /**
+     * @test
+     */
+    public function testReturnsFalseWhenAuth0UserIdIsNull(): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = [
+            'uid' => 1,
+            'username' => 'regular_user',
+            // auth0_user_id key doesn't exist
+        ];
+
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $result = $this->subject->hasValidAuth0Session();
+
+        self::assertFalse($result);
+    }
+
+    /**
+     * @test
+     */
+    public function testReturnsTrueWhenAuth0SessionIsValid(): void
+    {
+        // Setup backend user with Auth0 authentication
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = [
+            'uid' => 2,
+            'username' => 'auth0_user',
+            'auth0_user_id' => 'auth0|123456789',
+        ];
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        // Create partial mock to stub the hasAuth0Session method
+        // This avoids calling ApplicationFactory::build() which requires functional environment
+        $validatorMock = $this->getMockBuilder(Auth0SessionValidator::class)
+            ->setConstructorArgs([$this->configuration])
+            ->onlyMethods(['hasAuth0Session'])
+            ->getMock();
+
+        // Stub hasAuth0Session to return true (simulating valid Auth0 session)
+        $validatorMock->expects(self::once())
+            ->method('hasAuth0Session')
+            ->willReturn(true);
+
+        // Call the method
+        $result = $validatorMock->hasValidAuth0Session();
+
+        // Verify returns true when Auth0 session is valid
+        self::assertTrue($result);
+    }
+
+    /**
+     * @test
+     */
+    public function testReturnsFalseWhenAuth0SessionCheckFails(): void
+    {
+        // Setup backend user with Auth0 authentication
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = [
+            'uid' => 3,
+            'username' => 'auth0_session_fail_user',
+            'auth0_user_id' => 'auth0|987654321',
+        ];
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        // Create partial mock to stub the hasAuth0Session method
+        $validatorMock = $this->getMockBuilder(Auth0SessionValidator::class)
+            ->setConstructorArgs([$this->configuration])
+            ->onlyMethods(['hasAuth0Session'])
+            ->getMock();
+
+        // Stub hasAuth0Session to return false (simulating ApplicationFactory failure or invalid session)
+        // In the real implementation, exceptions are caught and false is returned
+        $validatorMock->expects(self::once())
+            ->method('hasAuth0Session')
+            ->willReturn(false);
+
+        // Call the method
+        $result = $validatorMock->hasValidAuth0Session();
+
+        // Verify returns false when Auth0 session check fails
+        self::assertFalse($result);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     ],
     "homepage": "https://www.Leuchtfeuer.com",
     "require": {
+        "php": "^7.4 || ^8.0",
         "auth0/auth0-php": "^8.1",
         "lcobucci/jwt": "^4.1",
         "symfony/http-foundation": "^5.4 || ^6.2",

--- a/composer.json
+++ b/composer.json
@@ -38,12 +38,12 @@
         "symfony/property-access": "^4.4 || ^5.4 || ^6.2",
         "symfony/property-info": "^5.4 || ^6.3",
         "symfony/serializer": "^4.4 || ^5.4 || ^6.2",
-        "typo3/cms-backend": "^11.5.7 || ^12.4",
-        "typo3/cms-core": "^11.5.7 || ^12.4",
-        "typo3/cms-extbase": "^11.5.7 || ^12.4",
-        "typo3/cms-extensionmanager": "^11.5.7 || ^12.4",
-        "typo3/cms-fluid": "^11.5.7 || ^12.4",
-        "typo3/cms-frontend": "^11.5.7 || ^12.4"
+        "typo3/cms-backend": "^11.5.7 || ^12.4.32",
+        "typo3/cms-core": "^11.5.7 || ^12.4.32",
+        "typo3/cms-extbase": "^11.5.7 || ^12.4.32",
+        "typo3/cms-extensionmanager": "^11.5.7 || ^12.4.32",
+        "typo3/cms-fluid": "^11.5.7 || ^12.4.32",
+        "typo3/cms-frontend": "^11.5.7 || ^12.4.32"
     },
     "replace": {
         "bitmotion/auth0": "self.version",

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -16,6 +16,9 @@ softLogout = 0
 # cat=Backend/60; type=string; label=LLL:EXT:auth0/Resources/Private/Language/locallang_em.xlf:backend.additional_authorize_parameters
 additionalAuthorizeParameters =
 
+# cat=Backend/60; type=boolean; label=LLL:EXT:auth0/Resources/Private/Language/locallang_em.xlf:backend.disable_sudo_mode_bypass
+disableSudoModeBypass = 0
+
 # cat=Frontend/10; type=boolean; label=LLL:EXT:auth0/Resources/Private/Language/locallang_em.xlf:frontend.enable_frontend_login
 enableFrontendLogin = 1
 


### PR DESCRIPTION
This PR is a backport from https://github.com/Leuchtfeuer/auth0-for-typo3/pull/55 for v5.

It implements the SudoModeRequiredEvent handler to allow Auth0-authenticated users to change their password without entering their current password when they have a valid Auth0 session.

Changes:

- Added SudoModeRequiredEventListener to bypass sudo mode for Auth0 users
- Implemented Auth0SessionValidator service to validate Auth0 sessions
- Added comprehensive unit tests for both components

The event listener checks if the current user is Auth0-authenticated and has a valid session. If both conditions are met, sudo mode verification is bypassed, allowing password changes without entering the current (non-existent) password.