### PR TITLE
[FEATURE] Merge existing users by email and username on Auth0 login [TER-459] [TER-460]

### DIFF
--- a/Classes/Configuration/Auth0Configuration.php
+++ b/Classes/Configuration/Auth0Configuration.php
@@ -52,6 +52,26 @@ class Auth0Configuration implements SingletonInterface
         }
     }
 
+    /**
+     * Resolves the Auth0 source property mapped onto a given TYPO3 database field
+     * by inspecting the YAML property mapping. Returns null if no mapping exists.
+     */
+    public function getAuth0PropertyForDatabaseField(string $tableName, string $databaseField): ?string
+    {
+        $mapping = $this->load()['properties'][$tableName] ?? [];
+        foreach ($mapping as $properties) {
+            if (!is_array($properties)) {
+                continue;
+            }
+            foreach ($properties as $property) {
+                if (($property['databaseField'] ?? null) === $databaseField) {
+                    return $property['auth0Property'] ?? null;
+                }
+            }
+        }
+        return null;
+    }
+
     public function write(array $configuration): void
     {
         if (!file_exists($this->configPath)) {

--- a/Classes/Domain/Repository/UserRepository.php
+++ b/Classes/Domain/Repository/UserRepository.php
@@ -72,6 +72,47 @@ class UserRepository implements LoggerAwareInterface
     }
 
     /**
+     * Find user by email AND username. Used for OAuth provider migration:
+     * matches an existing user whose auth0_user_id was issued by a previous provider.
+     *
+     * The QueryBuilder applies the default restriction set (DeletedRestriction,
+     * HiddenRestriction, StartTime/EndTime) automatically, so disabled or deleted
+     * users are NOT returned by default. Callers that need to match such records
+     * must invoke removeRestrictions() on this repository beforehand.
+     *
+     * @return array<string, mixed>|null
+     * @throws Exception
+     */
+    public function getUserByEmailAndUsername(string $email, string $username): ?array
+    {
+        $this->queryBuilder
+            ->select('*')
+            ->from($this->tableName)
+            ->where(
+                $this->expressionBuilder->eq(
+                    'email',
+                    $this->queryBuilder->createNamedParameter($email)
+                ),
+                $this->expressionBuilder->eq(
+                    'username',
+                    $this->queryBuilder->createNamedParameter($username)
+                )
+            );
+        $this->logger?->debug(
+            sprintf(
+                '[%s] Executed SELECT query: %s',
+                $this->tableName,
+                $this->queryBuilder->getSQL()
+            )
+        );
+        $user = $this->queryBuilder
+            ->executeQuery()
+            ->fetchAssociative();
+
+        return ($user !== false) ? $user : null;
+    }
+
+    /**
      * Removes DeletedRestriction and / or HiddenRestriction from QueryBuilder.
      * Depends on extension configuration.
      */

--- a/Classes/Domain/Transfer/EmAuth0Configuration.php
+++ b/Classes/Domain/Transfer/EmAuth0Configuration.php
@@ -42,6 +42,8 @@ class EmAuth0Configuration implements SingletonInterface
 
     protected string $userIdentifier = 'sub';
 
+    protected bool $mergeUsersByEmailAndUsername = false;
+
     /**
      * @throws ExtensionConfigurationExtensionNotConfiguredException
      * @throws ExtensionConfigurationPathDoesNotExistException
@@ -136,5 +138,10 @@ class EmAuth0Configuration implements SingletonInterface
     public function getUserIdentifier(): string
     {
         return $this->userIdentifier;
+    }
+
+    public function isMergeUsersByEmailAndUsername(): bool
+    {
+        return $this->mergeUsersByEmailAndUsername;
     }
 }

--- a/Classes/Service/AuthenticationService.php
+++ b/Classes/Service/AuthenticationService.php
@@ -213,7 +213,7 @@ class AuthenticationService extends BasicAuthenticationService
      */
     protected function insertOrUpdateUser(): void
     {
-        $this->user = $this->userUtility->checkIfUserExists($this->tableName, $this->userInfo[$this->userIdentifier]);
+        $this->user = $this->userUtility->checkIfUserExists($this->tableName, $this->userInfo);
 
         // Insert a new user into database
         if ($this->user === []) {

--- a/Classes/Utility/UserUtility.php
+++ b/Classes/Utility/UserUtility.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Leuchtfeuer\Auth0\Utility;
 
 use Doctrine\DBAL\Exception as DBALException;
+use Leuchtfeuer\Auth0\Configuration\Auth0Configuration;
 use Leuchtfeuer\Auth0\Domain\Repository\UserRepositoryFactory;
 use Leuchtfeuer\Auth0\Domain\Transfer\EmAuth0Configuration;
 use Psr\Log\LoggerAwareInterface;
@@ -34,20 +35,77 @@ class UserUtility implements SingletonInterface, LoggerAwareInterface
         protected readonly PasswordHashFactory $passwordHashFactory,
         protected readonly Random $random,
         protected readonly UserRepositoryFactory $userRepositoryFactory,
+        protected readonly Auth0Configuration $auth0Configuration,
     ) {
         $this->configuration = new EmAuth0Configuration();
     }
 
     /**
+     * @param array<string, mixed> $userInfo
      * @return array<string, mixed>
      * @throws DBALException
      */
-    public function checkIfUserExists(string $tableName, string $auth0UserId): array
+    public function checkIfUserExists(string $tableName, array $userInfo): array
     {
+        $auth0UserId = (string)($userInfo[$this->configuration->getUserIdentifier()] ?? '');
+
         $userRepository = $this->userRepositoryFactory->create($tableName);
         $user = $userRepository->getUserByAuth0Id($auth0UserId);
 
+        if ($user === null && $this->configuration->isMergeUsersByEmailAndUsername()) {
+            $user = $this->findExistingUserByEmailAndUsername($tableName, $userInfo);
+        }
+
         return $user ?? $this->findUserWithoutRestrictions($tableName, $auth0UserId);
+    }
+
+    /**
+     * Migration helper: locate an existing TYPO3 user by email + username when
+     * no auth0_user_id match exists. If found, update its auth0_user_id to the
+     * new value so subsequent logins match via the standard path.
+     *
+     * @param array<string, mixed> $userInfo
+     * @return array<string, mixed>|null
+     */
+    protected function findExistingUserByEmailAndUsername(string $tableName, array $userInfo): ?array
+    {
+        $email = (string)($userInfo['email'] ?? '');
+        $usernameAuth0Property = $this->auth0Configuration->getAuth0PropertyForDatabaseField($tableName, 'username') ?? 'nickname';
+        $username = (string)($userInfo[$usernameAuth0Property] ?? '');
+        $newAuth0UserId = (string)($userInfo[$this->configuration->getUserIdentifier()] ?? '');
+
+        if ($email === '' || $username === '' || $newAuth0UserId === '') {
+            return null;
+        }
+
+        $userRepository = $this->userRepositoryFactory->create($tableName);
+        $userRepository->removeRestrictions();
+        $userRepository->setOrdering('uid', 'ASC');
+        $userRepository->setMaxResults(1);
+        $user = $userRepository->getUserByEmailAndUsername($email, $username);
+
+        if ($user === null) {
+            return null;
+        }
+
+        $sets = ['auth0_user_id' => $newAuth0UserId];
+        if ($this->configuration->isReactivateDisabledBackendUsers() && (int)($user['disable'] ?? 0) === 1) {
+            $sets['disable'] = 0;
+        }
+        if ($this->configuration->isReactivateDeletedBackendUsers() && (int)($user['deleted'] ?? 0) === 1) {
+            $sets['deleted'] = 0;
+        }
+
+        $updateRepository = $this->userRepositoryFactory->create($tableName);
+        $updateRepository->updateUserByUid($sets, (int)$user['uid']);
+
+        $this->logger?->notice(sprintf(
+            'Merged existing user (uid=%d) with new auth0_user_id "%s" via email+username match.',
+            (int)$user['uid'],
+            $newAuth0UserId
+        ));
+
+        return array_merge($user, $sets);
     }
 
     /**

--- a/Resources/Private/Language/de.locallang_em.xlf
+++ b/Resources/Private/Language/de.locallang_em.xlf
@@ -27,6 +27,10 @@
         <source><![CDATA[Additional Query Parameters: Additional query parameters for backend authentication (e.g. "access_type=offline&connection=google-oauth2")]]></source>
         <target><![CDATA[Zusätzliche Query Parameter: Zusätzliche query Parameter für die Backend-Authentifizierung (z.B.: "access_type=offline&connection=google-oauth2")]]></target>
       </trans-unit>
+      <trans-unit id="backend.merge_users_by_email_and_username" resname="backend.merge_users_by_email_and_username">
+        <source>Merge Existing Users: When no Auth0 ID match is found, look up an existing backend user by email and username and update its auth0_user_id. Useful when migrating between OAuth providers (e.g. Google to Auth0) to preserve TYPO3 edit history.</source>
+        <target>Bestehende Benutzer zusammenführen: Wenn kein Treffer über die Auth0-ID besteht, wird ein vorhandener Backend-Benutzer anhand von E-Mail und Loginname gesucht und dessen auth0_user_id aktualisiert. Nützlich beim Wechsel des OAuth-Providers (z. B. Google → Auth0), um die TYPO3-Bearbeitungshistorie zu erhalten.</target>
+      </trans-unit>
       <trans-unit id="frontend.enable_frontend_login" resname="frontend.enable_frontend_login">
         <source>Frontend Log In: Enable Auth0 log in for TYPO3 frontend</source>
         <target>Webseiten Login: Aktiviere Auth0 zur Anmeldung auf deiner Webseite</target>

--- a/Resources/Private/Language/locallang_em.xlf
+++ b/Resources/Private/Language/locallang_em.xlf
@@ -24,6 +24,9 @@
       <trans-unit id="backend.disable_sudo_mode_bypass" resname="backend.disable_sudo_mode_bypass">
         <source>Disable Sudo Mode Bypassing: If set, a password confirmation dialog is shown on accessing modules in the Admin Tools section</source>
       </trans-unit>
+      <trans-unit id="backend.merge_users_by_email_and_username" resname="backend.merge_users_by_email_and_username">
+        <source>Merge Existing Users: When no Auth0 ID match is found, look up an existing backend user by email and username and update its auth0_user_id. Useful when migrating between OAuth providers (e.g. Google to Auth0) to preserve TYPO3 edit history.</source>
+      </trans-unit>
       <trans-unit id="frontend.enable_frontend_login" resname="frontend.enable_frontend_login">
         <source>Frontend Log In: Enable Auth0 log in for TYPO3 frontend</source>
       </trans-unit>

--- a/Tests/Unit/Configuration/Auth0ConfigurationTest.php
+++ b/Tests/Unit/Configuration/Auth0ConfigurationTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "Auth0" extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
+ */
+
+namespace Leuchtfeuer\Auth0\Tests\Unit\Configuration;
+
+use Leuchtfeuer\Auth0\Configuration\Auth0Configuration;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class Auth0ConfigurationTest extends TestCase
+{
+    #[Test]
+    public function getAuth0PropertyForDatabaseFieldReturnsMappedAuth0Property(): void
+    {
+        $subject = $this->createSubjectWithMapping([
+            'properties' => [
+                'be_users' => [
+                    'root' => [
+                        ['auth0Property' => 'nickname', 'databaseField' => 'username'],
+                        ['auth0Property' => 'email_verified', 'databaseField' => 'disable'],
+                    ],
+                    'user_metadata' => [],
+                    'app_metadata' => [],
+                ],
+            ],
+        ]);
+
+        self::assertSame('nickname', $subject->getAuth0PropertyForDatabaseField('be_users', 'username'));
+        self::assertSame('email_verified', $subject->getAuth0PropertyForDatabaseField('be_users', 'disable'));
+    }
+
+    #[Test]
+    public function getAuth0PropertyForDatabaseFieldHonoursOverriddenMapping(): void
+    {
+        $subject = $this->createSubjectWithMapping([
+            'properties' => [
+                'be_users' => [
+                    'root' => [
+                        ['auth0Property' => 'preferred_username', 'databaseField' => 'username'],
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertSame('preferred_username', $subject->getAuth0PropertyForDatabaseField('be_users', 'username'));
+    }
+
+    #[Test]
+    public function getAuth0PropertyForDatabaseFieldReturnsNullWhenNoMappingExists(): void
+    {
+        $subject = $this->createSubjectWithMapping([
+            'properties' => [
+                'be_users' => [
+                    'root' => [
+                        ['auth0Property' => 'nickname', 'databaseField' => 'username'],
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertNull($subject->getAuth0PropertyForDatabaseField('be_users', 'email'));
+        self::assertNull($subject->getAuth0PropertyForDatabaseField('unknown_table', 'username'));
+    }
+
+    /**
+     * @param array<string, mixed> $mapping
+     */
+    private function createSubjectWithMapping(array $mapping): Auth0Configuration
+    {
+        return new class ($mapping) extends Auth0Configuration {
+            /** @param array<string, mixed> $mapping */
+            public function __construct(private readonly array $mapping)
+            {
+                // Skip parent constructor: file system paths are irrelevant for unit tests.
+            }
+
+            public function load(): array
+            {
+                return $this->mapping;
+            }
+        };
+    }
+}

--- a/Tests/Unit/Utility/UserUtilityTest.php
+++ b/Tests/Unit/Utility/UserUtilityTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "Auth0" extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * (c) Leuchtfeuer Digital Marketing <dev@Leuchtfeuer.com>
+ */
+
+namespace Leuchtfeuer\Auth0\Tests\Unit\Utility;
+
+use Leuchtfeuer\Auth0\Configuration\Auth0Configuration;
+use Leuchtfeuer\Auth0\Domain\Repository\UserRepository;
+use Leuchtfeuer\Auth0\Domain\Repository\UserRepositoryFactory;
+use Leuchtfeuer\Auth0\Domain\Transfer\EmAuth0Configuration;
+use Leuchtfeuer\Auth0\Utility\UserUtility;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Crypto\PasswordHashing\PasswordHashFactory;
+use TYPO3\CMS\Core\Crypto\Random;
+
+class UserUtilityTest extends TestCase
+{
+    private const TABLE = 'be_users';
+
+    private PasswordHashFactory&Stub $passwordHashFactory;
+    private Random&Stub $random;
+    private UserRepositoryFactory $userRepositoryFactory;
+    private Auth0Configuration&Stub $auth0Configuration;
+    private EmAuth0Configuration&Stub $emConfiguration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->passwordHashFactory = self::createStub(PasswordHashFactory::class);
+        $this->random = self::createStub(Random::class);
+        $this->userRepositoryFactory = self::createStub(UserRepositoryFactory::class);
+        $this->auth0Configuration = self::createStub(Auth0Configuration::class);
+        $this->emConfiguration = self::createStub(EmAuth0Configuration::class);
+        $this->emConfiguration->method('getUserIdentifier')->willReturn('sub');
+    }
+
+    #[Test]
+    public function checkIfUserExistsReturnsExistingUserWhenAuth0IdMatches(): void
+    {
+        $expectedUser = ['uid' => 42, 'auth0_user_id' => 'auth0|42'];
+
+        $repository = $this->createMock(UserRepository::class);
+        $repository->expects(self::once())
+            ->method('getUserByAuth0Id')
+            ->with('auth0|42')
+            ->willReturn($expectedUser);
+
+        $this->userRepositoryFactory->method('create')->willReturn($repository);
+
+        $subject = $this->createSubject();
+
+        $result = $subject->checkIfUserExists(self::TABLE, ['sub' => 'auth0|42', 'email' => 'a@b']);
+
+        self::assertSame($expectedUser, $result);
+    }
+
+    #[Test]
+    public function checkIfUserExistsFallsBackToFindUserWithoutRestrictionsWhenMergeOptionDisabled(): void
+    {
+        $reactivated = ['uid' => 7, 'auth0_user_id' => 'auth0|gone'];
+
+        // Primary lookup misses, fallback (findUserWithoutRestrictions) hits.
+        $primaryRepo = self::createStub(UserRepository::class);
+        $primaryRepo->method('getUserByAuth0Id')->willReturn(null);
+
+        $fallbackRepo = self::createStub(UserRepository::class);
+        $fallbackRepo->method('getUserByAuth0Id')->willReturn($reactivated);
+        $reactivateRepo = self::createStub(UserRepository::class);
+
+        $this->userRepositoryFactory->method('create')
+            ->willReturnOnConsecutiveCalls($primaryRepo, $fallbackRepo, $reactivateRepo);
+
+        $this->emConfiguration->method('isMergeUsersByEmailAndUsername')->willReturn(false);
+
+        $subject = $this->createSubject();
+
+        $result = $subject->checkIfUserExists(self::TABLE, ['sub' => 'auth0|gone', 'email' => 'x@y', 'nickname' => 'x']);
+
+        self::assertSame($reactivated, array_intersect_key($reactivated, $result));
+    }
+
+    #[Test]
+    public function checkIfUserExistsMergesByEmailAndUsernameAndUpdatesAuth0UserId(): void
+    {
+        $existing = ['uid' => 99, 'auth0_user_id' => 'google-oauth2|old', 'disable' => 0, 'deleted' => 0];
+
+        $primaryRepo = self::createStub(UserRepository::class);
+        $primaryRepo->method('getUserByAuth0Id')->willReturn(null);
+
+        $mergeRepo = $this->createMock(UserRepository::class);
+        $mergeRepo->expects(self::once())->method('removeRestrictions');
+        $mergeRepo->expects(self::once())->method('setOrdering')->with('uid', 'ASC');
+        $mergeRepo->expects(self::once())->method('setMaxResults')->with(1);
+        $mergeRepo->expects(self::once())
+            ->method('getUserByEmailAndUsername')
+            ->with('user@example.com', 'old.login')
+            ->willReturn($existing);
+
+        $updateRepo = $this->createMock(UserRepository::class);
+        $updateRepo->expects(self::once())
+            ->method('updateUserByUid')
+            ->with(['auth0_user_id' => 'auth0|new'], 99);
+
+        $this->userRepositoryFactory->method('create')
+            ->willReturnOnConsecutiveCalls($primaryRepo, $mergeRepo, $updateRepo);
+
+        $this->emConfiguration->method('isMergeUsersByEmailAndUsername')->willReturn(true);
+        $this->emConfiguration->method('isReactivateDisabledBackendUsers')->willReturn(false);
+        $this->emConfiguration->method('isReactivateDeletedBackendUsers')->willReturn(false);
+        $this->auth0Configuration->method('getAuth0PropertyForDatabaseField')->willReturn('nickname');
+
+        $subject = $this->createSubject();
+
+        $result = $subject->checkIfUserExists(self::TABLE, [
+            'sub' => 'auth0|new',
+            'email' => 'user@example.com',
+            'nickname' => 'old.login',
+        ]);
+
+        self::assertSame(99, $result['uid']);
+        self::assertSame('auth0|new', $result['auth0_user_id']);
+    }
+
+    #[Test]
+    public function checkIfUserExistsReactivatesDisabledOrDeletedUserWhenSettingsAllow(): void
+    {
+        $existing = ['uid' => 5, 'auth0_user_id' => 'old', 'disable' => 1, 'deleted' => 1];
+
+        $primaryRepo = self::createStub(UserRepository::class);
+        $primaryRepo->method('getUserByAuth0Id')->willReturn(null);
+
+        $mergeRepo = self::createStub(UserRepository::class);
+        $mergeRepo->method('getUserByEmailAndUsername')->willReturn($existing);
+
+        $updateRepo = $this->createMock(UserRepository::class);
+        $updateRepo->expects(self::once())
+            ->method('updateUserByUid')
+            ->with(
+                self::callback(static fn(array $sets): bool => $sets === [
+                    'auth0_user_id' => 'auth0|new',
+                    'disable' => 0,
+                    'deleted' => 0,
+                ]),
+                5
+            );
+
+        $this->userRepositoryFactory->method('create')
+            ->willReturnOnConsecutiveCalls($primaryRepo, $mergeRepo, $updateRepo);
+
+        $this->emConfiguration->method('isMergeUsersByEmailAndUsername')->willReturn(true);
+        $this->emConfiguration->method('isReactivateDisabledBackendUsers')->willReturn(true);
+        $this->emConfiguration->method('isReactivateDeletedBackendUsers')->willReturn(true);
+        $this->auth0Configuration->method('getAuth0PropertyForDatabaseField')->willReturn('nickname');
+
+        $subject = $this->createSubject();
+        $subject->checkIfUserExists(self::TABLE, [
+            'sub' => 'auth0|new',
+            'email' => 'a@b',
+            'nickname' => 'foo',
+        ]);
+    }
+
+    #[Test]
+    public function checkIfUserExistsSkipsMergeWhenEmailOrUsernameIsEmpty(): void
+    {
+        $primaryRepo = self::createStub(UserRepository::class);
+        $primaryRepo->method('getUserByAuth0Id')->willReturn(null);
+
+        $fallbackRepo = self::createStub(UserRepository::class);
+        $fallbackRepo->method('getUserByAuth0Id')->willReturn(null);
+
+        // Crucial: factory is only called for primary lookup + fallback, NOT for merge attempt.
+        $factory = $this->createMock(UserRepositoryFactory::class);
+        $factory->expects(self::exactly(2))
+            ->method('create')
+            ->willReturnOnConsecutiveCalls($primaryRepo, $fallbackRepo);
+        $this->userRepositoryFactory = $factory;
+
+        $this->emConfiguration->method('isMergeUsersByEmailAndUsername')->willReturn(true);
+        $this->auth0Configuration->method('getAuth0PropertyForDatabaseField')->willReturn('nickname');
+
+        $subject = $this->createSubject();
+
+        // No nickname value -> guard prevents merge attempt.
+        $subject->checkIfUserExists(self::TABLE, [
+            'sub' => 'auth0|new',
+            'email' => 'a@b',
+            'nickname' => '',
+        ]);
+    }
+
+    #[Test]
+    public function checkIfUserExistsFallsBackToNicknameWhenYamlMappingMissing(): void
+    {
+        $existing = ['uid' => 1, 'auth0_user_id' => 'old', 'disable' => 0, 'deleted' => 0];
+
+        $primaryRepo = self::createStub(UserRepository::class);
+        $primaryRepo->method('getUserByAuth0Id')->willReturn(null);
+
+        $mergeRepo = $this->createMock(UserRepository::class);
+        $mergeRepo->expects(self::once())
+            ->method('getUserByEmailAndUsername')
+            ->with('a@b', 'fallback.value')
+            ->willReturn($existing);
+
+        $updateRepo = self::createStub(UserRepository::class);
+
+        $this->userRepositoryFactory->method('create')
+            ->willReturnOnConsecutiveCalls($primaryRepo, $mergeRepo, $updateRepo);
+
+        $this->emConfiguration->method('isMergeUsersByEmailAndUsername')->willReturn(true);
+        $this->auth0Configuration->method('getAuth0PropertyForDatabaseField')->willReturn(null);
+
+        $subject = $this->createSubject();
+        $subject->checkIfUserExists(self::TABLE, [
+            'sub' => 'auth0|new',
+            'email' => 'a@b',
+            'nickname' => 'fallback.value',
+        ]);
+    }
+
+    private function createSubject(): UserUtility
+    {
+        $subject = (new \ReflectionClass(UserUtility::class))->newInstanceWithoutConstructor();
+        $reflection = new \ReflectionClass(UserUtility::class);
+
+        foreach ([
+            'passwordHashFactory' => $this->passwordHashFactory,
+            'random' => $this->random,
+            'userRepositoryFactory' => $this->userRepositoryFactory,
+            'auth0Configuration' => $this->auth0Configuration,
+            'configuration' => $this->emConfiguration,
+        ] as $name => $value) {
+            $property = $reflection->getProperty($name);
+            $property->setValue($subject, $value);
+        }
+
+        return $subject;
+    }
+}

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -19,6 +19,9 @@ additionalAuthorizeParameters =
 # cat=Backend/60; type=boolean; label=LLL:EXT:auth0/Resources/Private/Language/locallang_em.xlf:backend.disable_sudo_mode_bypass
 disableSudoModeBypass = 0
 
+# cat=Backend/70; type=boolean; label=LLL:EXT:auth0/Resources/Private/Language/locallang_em.xlf:backend.merge_users_by_email_and_username
+mergeUsersByEmailAndUsername = 0
+
 # cat=Token/20; type=string; label=LLL:EXT:auth0/Resources/Private/Language/locallang_em.xlf:token.private_key_file
 privateKeyFile =
 


### PR DESCRIPTION
Switching OAuth login/providers changes the auth0_user_id and would otherwise create a duplicate backend user, severing TYPO3 edit history. The new EM option falls back to email + YAML-mapped username and rewrites auth0_user_id in place.