### PR TITLE
[FEATURE] Merge existing users by email and username on Auth0 login [TER-459] [TER-460]

### DIFF
--- a/Classes/Configuration/Auth0Configuration.php
+++ b/Classes/Configuration/Auth0Configuration.php
@@ -141,6 +141,19 @@ class Auth0Configuration implements SingletonInterface
         return $configuration;
     }
 
+    public function getAuth0PropertyForDatabaseField(string $tableName, string $databaseField): ?string
+    {
+        $mapping = $this->load()['properties'][$tableName] ?? [];
+        foreach ($mapping as $properties) {
+            foreach ($properties as $property) {
+                if (($property['databaseField'] ?? null) === $databaseField) {
+                    return $property['auth0Property'] ?? null;
+                }
+            }
+        }
+        return null;
+    }
+
     protected function getYamlFileLoader(): YamlFileLoader
     {
         return GeneralUtility::makeInstance(YamlFileLoader::class);

--- a/Classes/Domain/Repository/UserRepository.php
+++ b/Classes/Domain/Repository/UserRepository.php
@@ -72,6 +72,23 @@ class UserRepository implements LoggerAwareInterface
     }
 
     /**
+     * Find user by email AND username. Used for OAuth provider migration.
+     */
+    public function getUserByEmailAndUsername(string $email, string $username): ?array
+    {
+        $this->queryBuilder
+            ->select('*')
+            ->from($this->tableName)
+            ->where(
+                $this->expressionBuilder->eq('email', $this->queryBuilder->createNamedParameter($email)),
+                $this->expressionBuilder->eq('username', $this->queryBuilder->createNamedParameter($username))
+            );
+        $user = $this->queryBuilder->execute()->fetchAssociative();
+
+        return ($user !== false) ? $user : null;
+    }
+
+    /**
      * Removes DeletedRestriction and / or HiddenRestriction from QueryBuilder.
      * Depends on extension configuration.
      */

--- a/Classes/Domain/Transfer/EmAuth0Configuration.php
+++ b/Classes/Domain/Transfer/EmAuth0Configuration.php
@@ -38,6 +38,8 @@ class EmAuth0Configuration implements SingletonInterface
 
     protected $softLogout = false;
 
+    protected $mergeUsersByEmailAndUsername = false;
+
     protected $additionalAuthorizeParameters = '';
 
     protected $enableFrontendLogin = true;
@@ -108,6 +110,11 @@ class EmAuth0Configuration implements SingletonInterface
     public function isSoftLogout(): bool
     {
         return (bool)$this->softLogout;
+    }
+
+    public function isMergeUsersByEmailAndUsername(): bool
+    {
+        return (bool)$this->mergeUsersByEmailAndUsername;
     }
 
     public function getAdditionalAuthorizeParameters(): array

--- a/Classes/Service/AuthenticationService.php
+++ b/Classes/Service/AuthenticationService.php
@@ -272,7 +272,7 @@ class AuthenticationService extends BasicAuthenticationService
     protected function insertOrUpdateUser(): void
     {
         $userUtility = GeneralUtility::makeInstance(UserUtility::class);
-        $this->user = $userUtility->checkIfUserExists($this->tableName, $this->userInfo[$this->userIdentifier]);
+        $this->user = $userUtility->checkIfUserExists($this->tableName, $this->userInfo);
 
         // Insert a new user into database
         if (empty($this->user)) {

--- a/Classes/Utility/UserUtility.php
+++ b/Classes/Utility/UserUtility.php
@@ -16,16 +16,19 @@ namespace Leuchtfeuer\Auth0\Utility;
 use Auth0\SDK\Auth0;
 use Auth0\SDK\Utility\HttpResponse;
 use GuzzleHttp\Utils;
+use Leuchtfeuer\Auth0\Configuration\Auth0Configuration;
 use Leuchtfeuer\Auth0\Domain\Repository\ApplicationRepository;
 use Leuchtfeuer\Auth0\Domain\Repository\UserRepository;
 use Leuchtfeuer\Auth0\Domain\Transfer\EmAuth0Configuration;
 use Leuchtfeuer\Auth0\Utility\Database\UpdateUtility;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Crypto\PasswordHashing\InvalidPasswordHashException;
 use TYPO3\CMS\Core\Crypto\PasswordHashing\PasswordHashFactory;
 use TYPO3\CMS\Core\Crypto\Random;
+use TYPO3\CMS\Core\Http\ApplicationType;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -41,12 +44,76 @@ class UserUtility implements SingletonInterface, LoggerAwareInterface
         $this->configuration = new EmAuth0Configuration();
     }
 
-    public function checkIfUserExists(string $tableName, string $auth0UserId): array
+    public function checkIfUserExists(string $tableName, array $userInfo): array
     {
+        $auth0UserId = $userInfo[$this->configuration->getUserIdentifier()] ?? '';
         $userRepository = GeneralUtility::makeInstance(UserRepository::class, $tableName);
         $user = $userRepository->getUserByAuth0Id($auth0UserId);
 
+        if ($user === null && $this->configuration->isMergeUsersByEmailAndUsername()) {
+            $user = $this->findExistingUserByEmailAndUsername($tableName, $userInfo);
+        }
+
         return $user ?? $this->findUserWithoutRestrictions($tableName, $auth0UserId);
+    }
+
+    protected function findExistingUserByEmailAndUsername(string $tableName, array $userInfo): ?array
+    {
+        $email = $userInfo['email'] ?? '';
+        $auth0Configuration = GeneralUtility::makeInstance(Auth0Configuration::class);
+        $usernameAuth0Property = $auth0Configuration->getAuth0PropertyForDatabaseField($tableName, 'username') ?? 'nickname';
+        $username = $userInfo[$usernameAuth0Property] ?? '';
+
+        if ($email === '' || $username === '') {
+            return null;
+        }
+
+        $userRepository = GeneralUtility::makeInstance(UserRepository::class, $tableName);
+        $userRepository->removeRestrictions();
+        $userRepository->setOrdering('uid', 'ASC');
+        $userRepository->setMaxResults(1);
+        $user = $userRepository->getUserByEmailAndUsername($email, $username);
+
+        if ($user === null) {
+            return null;
+        }
+
+        $newAuth0UserId = $userInfo[$this->configuration->getUserIdentifier()] ?? '';
+        if ($newAuth0UserId === '') {
+            return null;
+        }
+
+        $sets = ['auth0_user_id' => $newAuth0UserId];
+
+        $isFrontend = ($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof ServerRequestInterface
+            && ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend();
+
+        if ($isFrontend) {
+            if ($this->configuration->isReactivateDisabledFrontendUsers() && (int)($user['disable'] ?? 0) === 1) {
+                $sets['disable'] = 0;
+            }
+            if ($this->configuration->isReactivateDeletedFrontendUsers() && (int)($user['deleted'] ?? 0) === 1) {
+                $sets['deleted'] = 0;
+            }
+        } else {
+            if ($this->configuration->isReactivateDisabledBackendUsers() && (int)($user['disable'] ?? 0) === 1) {
+                $sets['disable'] = 0;
+            }
+            if ($this->configuration->isReactivateDeletedBackendUsers() && (int)($user['deleted'] ?? 0) === 1) {
+                $sets['deleted'] = 0;
+            }
+        }
+
+        $updateRepository = GeneralUtility::makeInstance(UserRepository::class, $tableName);
+        $updateRepository->updateUserByUid($sets, (int)$user['uid']);
+
+        $this->logger->notice(sprintf(
+            'Merged existing user (uid=%d) with new auth0_user_id "%s" via email+username match.',
+            (int)$user['uid'],
+            $newAuth0UserId
+        ));
+
+        return array_merge($user, $sets);
     }
 
     protected function findUserWithoutRestrictions(string $tableName, string $auth0UserId): array

--- a/Resources/Private/Language/de.locallang_em.xlf
+++ b/Resources/Private/Language/de.locallang_em.xlf
@@ -27,6 +27,10 @@
 				<source><![CDATA[Additional Query Parameters: Additional query parameters for backend authentication (e.g. "access_type=offline&connection=google-oauth2")]]></source>
 				<target><![CDATA[Zusätzliche Query Parameter: Zusätzliche query Parameter für die Backend-Authentifizierung (z.B.: "access_type=offline&connection=google-oauth2")]]></target>
 			</trans-unit>
+			<trans-unit id="backend.merge_users_by_email_and_username" resname="backend.merge_users_by_email_and_username">
+				<source>Merge with existing user by email + username when no Auth0 ID match. Used for OAuth provider migration.</source>
+				<target>Mit bestehendem Benutzer anhand E-Mail + Loginname zusammenführen, wenn kein Auth0-ID-Match besteht. Für Wechsel des OAuth-Providers.</target>
+			</trans-unit>
 			<trans-unit id="frontend.enable_frontend_login" resname="frontend.enable_frontend_login">
 				<source>Frontend Log In: Enable Auth0 log in for TYPO3 frontend</source>
 				<target>Webseiten Login: Aktiviere Auth0 zur Anmeldung auf deiner Webseite</target>

--- a/Resources/Private/Language/locallang_em.xlf
+++ b/Resources/Private/Language/locallang_em.xlf
@@ -24,6 +24,9 @@
             <trans-unit id="backend.disable_sudo_mode_bypass" resname="backend.disable_sudo_mode_bypass">
                 <source>Disable Sudo Mode Bypassing: If set, a password confirmation dialog is shown on accessing modules in the Admin Tools section</source>
             </trans-unit>
+			<trans-unit id="backend.merge_users_by_email_and_username" resname="backend.merge_users_by_email_and_username">
+				<source>Merge with existing user by email + username when no Auth0 ID match. Used for OAuth provider migration.</source>
+			</trans-unit>
 			<trans-unit id="frontend.enable_frontend_login" resname="frontend.enable_frontend_login">
 				<source>Frontend Log In: Enable Auth0 log in for TYPO3 frontend</source>
 			</trans-unit>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -19,6 +19,9 @@ additionalAuthorizeParameters =
 # cat=Backend/60; type=boolean; label=LLL:EXT:auth0/Resources/Private/Language/locallang_em.xlf:backend.disable_sudo_mode_bypass
 disableSudoModeBypass = 0
 
+# cat=Backend/70; type=boolean; label=LLL:EXT:auth0/Resources/Private/Language/locallang_em.xlf:backend.merge_users_by_email_and_username
+mergeUsersByEmailAndUsername = 0
+
 # cat=Frontend/10; type=boolean; label=LLL:EXT:auth0/Resources/Private/Language/locallang_em.xlf:frontend.enable_frontend_login
 enableFrontendLogin = 1
 


### PR DESCRIPTION
Switching OAuth login users/providers changes the auth0_user_id and would otherwise create a duplicate backend user, severing TYPO3 edit history. The new EM option falls back to email + YAML-mapped username and rewrites auth0_user_id in place.