### PR TITLE
[Release 5.1.4] Auth0: Error with Optional User Mapping to Email [TER-477]

### DIFF
--- a/Classes/Configuration/Auth0Configuration.php
+++ b/Classes/Configuration/Auth0Configuration.php
@@ -154,6 +154,35 @@ class Auth0Configuration implements SingletonInterface
         return null;
     }
 
+    /**
+     * Resolves the Auth0 source property mapped onto a given TYPO3 database field
+     * including its configuration type bucket (root | user_metadata | app_metadata).
+     * Required to look up nested properties — a plain top-level lookup would miss
+     * mappings declared inside user_metadata or app_metadata.
+     *
+     * @return array{configurationType: string, auth0Property: string}|null
+     */
+    public function getAuth0MappingForDatabaseField(string $tableName, string $databaseField): ?array
+    {
+        $mapping = $this->load()['properties'][$tableName] ?? [];
+        foreach ($mapping as $configurationType => $properties) {
+            if (!is_array($properties)) {
+                continue;
+            }
+            foreach ($properties as $property) {
+                if (($property['databaseField'] ?? null) === $databaseField
+                    && isset($property['auth0Property'])
+                ) {
+                    return [
+                        'configurationType' => (string)$configurationType,
+                        'auth0Property' => (string)$property['auth0Property'],
+                    ];
+                }
+            }
+        }
+        return null;
+    }
+
     protected function getYamlFileLoader(): YamlFileLoader
     {
         return GeneralUtility::makeInstance(YamlFileLoader::class);

--- a/Classes/Domain/Repository/UserRepository.php
+++ b/Classes/Domain/Repository/UserRepository.php
@@ -197,11 +197,44 @@ class UserRepository implements LoggerAwareInterface
      */
     public function updateUserByAuth0Id(array $sets, string $auth0Id): void
     {
+        $this->warnIfAmbiguousAuth0Id($auth0Id);
         $this->resolveSets($sets);
         $this->queryBuilder->where(
             $this->expressionBuilder->eq('auth0_user_id', $this->queryBuilder->createNamedParameter($auth0Id))
         );
         $this->updateUser();
+    }
+
+    /**
+     * UPDATE statements have no row limit, so a duplicate auth0_user_id would
+     * silently mutate every matching record in lockstep — masking the duplicate
+     * instead of surfacing it. A warning here makes the situation visible.
+     */
+    protected function warnIfAmbiguousAuth0Id(string $auth0Id): void
+    {
+        $countQueryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable($this->tableName);
+        $countQueryBuilder->getRestrictions()->removeAll();
+        $count = (int)$countQueryBuilder
+            ->count('uid')
+            ->from($this->tableName)
+            ->where(
+                $countQueryBuilder->expr()->eq(
+                    'auth0_user_id',
+                    $countQueryBuilder->createNamedParameter($auth0Id)
+                )
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        if ($count > 1) {
+            $this->logger->warning(sprintf(
+                '[%s] %d rows match auth0_user_id "%s" — possible duplicate user records.',
+                $this->tableName,
+                $count,
+                $auth0Id
+            ));
+        }
     }
 
     /**

--- a/Classes/Utility/ParseFuncUtility.php
+++ b/Classes/Utility/ParseFuncUtility.php
@@ -32,11 +32,17 @@ class ParseFuncUtility implements SingletonInterface, LoggerAwareInterface
                 break;
 
             case Auth0Configuration::CONFIG_TYPE_USER:
-                $value = $this->getAuth0ValueRecursive($user[Auth0Configuration::CONFIG_TYPE_USER], explode('.', $auth0FieldName));
+                $bucket = $user[Auth0Configuration::CONFIG_TYPE_USER] ?? null;
+                $value = is_array($bucket)
+                    ? $this->getAuth0ValueRecursive($bucket, explode('.', $auth0FieldName))
+                    : null;
                 break;
 
             case Auth0Configuration::CONFIG_TYPE_APP:
-                $value = $this->getAuth0ValueRecursive($user[Auth0Configuration::CONFIG_TYPE_APP], explode('.', $auth0FieldName));
+                $bucket = $user[Auth0Configuration::CONFIG_TYPE_APP] ?? null;
+                $value = is_array($bucket)
+                    ? $this->getAuth0ValueRecursive($bucket, explode('.', $auth0FieldName))
+                    : null;
                 break;
 
             default:

--- a/Classes/Utility/UserUtility.php
+++ b/Classes/Utility/UserUtility.php
@@ -59,12 +59,22 @@ class UserUtility implements SingletonInterface, LoggerAwareInterface
 
     protected function findExistingUserByEmailAndUsername(string $tableName, array $userInfo): ?array
     {
-        $email = $userInfo['email'] ?? '';
-        $auth0Configuration = GeneralUtility::makeInstance(Auth0Configuration::class);
-        $usernameAuth0Property = $auth0Configuration->getAuth0PropertyForDatabaseField($tableName, 'username') ?? 'nickname';
-        $username = $userInfo[$usernameAuth0Property] ?? '';
+        $email = (string)($userInfo['email'] ?? '');
+        $username = $this->resolveUserInfoValue(
+            $tableName,
+            'username',
+            $userInfo,
+            ['configurationType' => Auth0Configuration::CONFIG_TYPE_ROOT, 'auth0Property' => 'nickname']
+        );
+        $newAuth0UserId = (string)($userInfo[$this->configuration->getUserIdentifier()] ?? '');
 
-        if ($email === '' || $username === '') {
+        if ($email === '' || $username === '' || $newAuth0UserId === '') {
+            $this->logger->notice(sprintf(
+                'Skip merge by email+username: missing values (email="%s", username="%s", auth0_user_id="%s").',
+                $email,
+                $username,
+                $newAuth0UserId
+            ));
             return null;
         }
 
@@ -75,11 +85,6 @@ class UserUtility implements SingletonInterface, LoggerAwareInterface
         $user = $userRepository->getUserByEmailAndUsername($email, $username);
 
         if ($user === null) {
-            return null;
-        }
-
-        $newAuth0UserId = $userInfo[$this->configuration->getUserIdentifier()] ?? '';
-        if ($newAuth0UserId === '') {
             return null;
         }
 
@@ -114,6 +119,35 @@ class UserUtility implements SingletonInterface, LoggerAwareInterface
         ));
 
         return array_merge($user, $sets);
+    }
+
+    /**
+     * Looks up a value in the Auth0 userInfo payload using the YAML property
+     * mapping for the given TYPO3 database field. Honours the configuration
+     * type (root, user_metadata, app_metadata) so nested properties resolve
+     * correctly. Falls back to the provided default mapping when the YAML
+     * does not declare one.
+     */
+    protected function resolveUserInfoValue(
+        string $tableName,
+        string $databaseField,
+        array $userInfo,
+        ?array $fallback = null
+    ): string {
+        $auth0Configuration = GeneralUtility::makeInstance(Auth0Configuration::class);
+        $mapping = $auth0Configuration->getAuth0MappingForDatabaseField($tableName, $databaseField) ?? $fallback;
+        if ($mapping === null) {
+            return '';
+        }
+
+        $parseFuncUtility = GeneralUtility::makeInstance(ParseFuncUtility::class);
+        $value = $parseFuncUtility->updateWithoutParseFunc(
+            $mapping['configurationType'],
+            $mapping['auth0Property'],
+            $userInfo
+        );
+
+        return $value === ParseFuncUtility::NO_AUTH0_VALUE ? '' : (string)$value;
     }
 
     protected function findUserWithoutRestrictions(string $tableName, string $auth0UserId): array

--- a/Documentation/About/Changelog/5-1-4.rst
+++ b/Documentation/About/Changelog/5-1-4.rst
@@ -1,0 +1,43 @@
+.. include:: ../../Includes.txt
+
+==========================
+Version 5.1.4 - 2026/05/12
+==========================
+
+This release fixes a regression in the ``mergeUsersByEmailAndUsername`` feature introduced in
+5.1.3 that prevented existing backend users from being matched when their Auth0 login method
+changed.
+
+Download
+========
+
+Download this version from the `TYPO3 extension repository <https://extensions.typo3.org/extension/auth0/>`__ or from
+`GitHub <https://github.com/Leuchtfeuer/auth0-for-typo3/releases/tag/v5.1.4>`__.
+
+Fixed
+=====
+
+* **Merge-by-email+username lookup honours configuration type:** When the YAML property mapping
+  placed the username inside ``user_metadata`` or ``app_metadata`` (instead of the root payload),
+  the lookup silently skipped the existing backend user and Auth0 then created a duplicate
+  ``be_users`` record. The lookup now resolves the username through the configured property
+  mapping — including its ``configurationType`` — and falls back to Auth0's ``nickname`` claim only
+  when no mapping is configured.
+
+Added
+=====
+
+* ``UserRepository::updateUserByAuth0Id()`` now logs a warning when more than one ``be_users`` row
+  matches the given ``auth0_user_id``. ``UPDATE`` has no implicit row limit, so a duplicate
+  identifier would otherwise mutate every matching record in lockstep and mask the duplication.
+
+* ``UserUtility::findExistingUserByEmailAndUsername()`` now emits a notice when the merge-by-
+  email+username path is skipped because ``email``, ``username``, or the new ``auth0_user_id`` is
+  missing from the Auth0 payload. This makes silent skips diagnosable in the TYPO3 log.
+
+All Changes
+===========
+
+This is a list of all changes in this release::
+
+    2026-05-12 [BUGFIX] Resolve merge-by-email+username lookup via configuration type [TER-477] [TER-478] (Commit 9979305 by Oliver Heins)

--- a/Documentation/About/Changelog/Index.rst
+++ b/Documentation/About/Changelog/Index.rst
@@ -16,6 +16,7 @@ List of Versions
     :maxdepth: 3
     :titlesonly:
 
+    5-1-4
     5-1-3
     5-1-2
     5-1-1

--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,7 @@
     "extra": {
         "typo3/cms": {
             "extension-key": "auth0",
+            "version": "5.1.4",
             "web-dir": ".Build/web"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -3,7 +3,7 @@
 $EM_CONF['auth0'] = [
     'title' => 'Auth0 for TYPO3',
     'description' => 'This extension allows you to log into a TYPO3 backend or frontend via Auth0. Auth0 is the solution you need for web, mobile, IoT, and internal applications. Loved by developers and trusted by enterprises.',
-    'version' => '5.1.3',
+    'version' => '5.1.4',
     'category' => 'misc',
     'constraints' => [
         'depends' => [


### PR DESCRIPTION
Merge-by-email+username silently skipped users when the YAML maps username into user_metadata, so Auth0 ID changes produced duplicate be_users rows. Lookup now honours the configuration type.