### PR TITLE
Switch storage to cookies; perform exchange in middleware [TER-482]

### DIFF
--- a/Classes/Factory/ApplicationFactory.php
+++ b/Classes/Factory/ApplicationFactory.php
@@ -14,7 +14,7 @@ namespace Leuchtfeuer\Auth0\Factory;
 use Auth0\SDK\Auth0;
 use Auth0\SDK\Configuration\SdkConfiguration;
 use Auth0\SDK\Exception\ConfigurationException;
-use Auth0\SDK\Store\SessionStore;
+use Auth0\SDK\Store\CookieStore;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use Leuchtfeuer\Auth0\Domain\Model\Application;
@@ -66,6 +66,14 @@ class ApplicationFactory
             'clientId' => $application->getClientId(),
             'clientSecret' => $application->getClientSecret(),
             'cookieSecret' => $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'],
+            // Storage is cookie-based: the SDK's PHP-session-backed store would
+            // call session_start() during backend requests and break the TYPO3
+            // Install Tool's FileSessionHandler, whose session_save_path() call
+            // throws when a PHP session is already active.
+            'cookiePath' => '/',
+            'cookieSecure' => (bool)($GLOBALS['TYPO3_CONF_VARS']['BE']['lockSSL'] ?? false),
+            'cookieSameSite' => 'Lax',
+            'cookieExpires' => 0,
             'domain' => $application->getDomain(),
             'id_token_alg' => $application->getSignatureAlgorithm(),
             'managementToken' => $managementToken ?? null,
@@ -77,8 +85,8 @@ class ApplicationFactory
             'scope' => $scope,
         ]);
         $auth0 = new Auth0($sdkConfiguration);
-        $auth0->configuration()->setSessionStorage(new SessionStore($auth0->configuration(), $sessionStorageId));
-        $auth0->configuration()->setTransientStorage(new SessionStore($auth0->configuration(), $sessionStorageId . '_transient'));
+        $auth0->configuration()->setSessionStorage(new CookieStore($auth0->configuration(), $sessionStorageId));
+        $auth0->configuration()->setTransientStorage(new CookieStore($auth0->configuration(), $sessionStorageId . '_transient'));
 
         return $auth0;
     }

--- a/Classes/Factory/ApplicationFactory.php
+++ b/Classes/Factory/ApplicationFactory.php
@@ -28,6 +28,7 @@ class ApplicationFactory
 {
     public const SESSION_PREFIX_BACKEND = 'BE';
 
+    /** @deprecated since v14, will be removed in v15 */
     public const SESSION_PREFIX_FRONTEND = 'FE';
 
     protected ?Application $application = null;
@@ -71,6 +72,8 @@ class ApplicationFactory
             // Install Tool's FileSessionHandler, whose session_save_path() call
             // throws when a PHP session is already active.
             'cookiePath' => '/',
+            // Intentionally tied to BE.lockSSL: the frontend session prefix is deprecated and
+            // the only caller of this factory is the backend login provider / callback middleware.
             'cookieSecure' => (bool)($GLOBALS['TYPO3_CONF_VARS']['BE']['lockSSL'] ?? false),
             'cookieSameSite' => 'Lax',
             'cookieExpires' => 0,

--- a/Classes/LoginProvider/Auth0Provider.php
+++ b/Classes/LoginProvider/Auth0Provider.php
@@ -184,23 +184,11 @@ class Auth0Provider implements LoginProviderInterface, LoggerAwareInterface, Sin
     protected function getUserInfo(): array
     {
         $this->setAuth0();
+        // The OAuth code exchange is performed by CallbackMiddleware before
+        // this provider runs, so user info is read directly from the Auth0
+        // SDK's cookie-backed session storage.
         $userInfo = $this->auth0->configuration()->getSessionStorage()?->get('user') ?? [];
-        if (!is_array($userInfo) || $userInfo === []) {
-            $queryParams = $this->getRequest()->getQueryParams();
-            try {
-                $this->logger?->notice('Try to get user via Auth0 API');
-                if (isset($queryParams['code']) && $this->auth0->exchange($this->getCallback(), $queryParams['code'], $queryParams['state'] ?? null)) {
-                    $userInfo = $this->auth0->getUser() ?? [];
-                } else {
-                    $this->logger?->notice('Exchange failed or no code present');
-                }
-            } catch (\Exception $exception) {
-                $this->logger?->critical($exception->getMessage());
-                $this->auth0->clear();
-            }
-        }
-
-        return $userInfo;
+        return is_array($userInfo) ? $userInfo : [];
     }
 
     /**

--- a/Classes/Middleware/CallbackMiddleware.php
+++ b/Classes/Middleware/CallbackMiddleware.php
@@ -16,6 +16,7 @@ namespace Leuchtfeuer\Auth0\Middleware;
 use Lcobucci\JWT\Token\DataSet;
 use Lcobucci\JWT\UnencryptedToken;
 use Leuchtfeuer\Auth0\Exception\TokenException;
+use Leuchtfeuer\Auth0\Factory\ApplicationFactory;
 use Leuchtfeuer\Auth0\LoginProvider\Auth0Provider;
 use Leuchtfeuer\Auth0\Utility\Database\UpdateUtilityFactory;
 use Leuchtfeuer\Auth0\Utility\TokenUtility;
@@ -33,8 +34,6 @@ class CallbackMiddleware implements MiddlewareInterface
     public const PATH = '/auth0/callback';
 
     public const TOKEN_PARAMETER = 'token';
-
-    private const BACKEND_URI = '%s/typo3/?loginProvider=%d&code=%s&state=%s';
 
     public function __construct(
         protected readonly UpdateUtilityFactory $updateUtilityFactory,
@@ -72,36 +71,72 @@ class CallbackMiddleware implements MiddlewareInterface
         ServerRequestInterface $request,
         DataSet $dataSet,
         string $issuer,
-    ): RedirectResponse {
+    ): ResponseInterface {
         if ($dataSet->get('redirectUri') !== null) {
             return new RedirectResponse($dataSet->get('redirectUri'), 302);
         }
 
         $queryParams = $request->getQueryParams();
-        $code = $queryParams['code'] ?? null;
-        $state = $queryParams['state'] ?? null;
+        $redirectUri = sprintf('%s/typo3/?loginProvider=%d', $issuer, Auth0Provider::LOGIN_PROVIDER);
 
-        if ($code === null || $code === '') {
-            $redirectUri = sprintf('%s/typo3/?loginProvider=%d', $issuer, Auth0Provider::LOGIN_PROVIDER);
-        } else {
-            $redirectUri = sprintf(
-                self::BACKEND_URI,
-                $issuer,
-                Auth0Provider::LOGIN_PROVIDER,
-                rawurlencode($code),
-                rawurlencode((string)$state)
-            );
-        }
-
-        // Add error parameters to backend uri if exists
+        // Carry forward error information if Auth0 redirected back with an error
         if (!empty($queryParams['error'] ?? null) && !empty($queryParams['error_description'] ?? null)) {
             $redirectUri .= sprintf(
                 '&error=%s&error_description=%s',
                 rawurlencode($queryParams['error']),
                 rawurlencode($queryParams['error_description'])
             );
+            return new RedirectResponse($redirectUri, 302);
         }
 
-        return new RedirectResponse($redirectUri, 302);
+        $code = $queryParams['code'] ?? null;
+        $state = $queryParams['state'] ?? null;
+        $applicationId = (int)($dataSet->get('application') ?? 0);
+
+        if ($code === null || $code === '' || $state === null || $applicationId === 0) {
+            return new RedirectResponse($redirectUri, 302);
+        }
+
+        $response = new RedirectResponse($redirectUri, 302);
+
+        // The Auth0 SDK persists session state via setrawcookie(), which queues
+        // Set-Cookie headers in PHP's global header buffer. TYPO3's response
+        // emitter then calls header('Set-Cookie: ...', replace=true) for the
+        // first PSR-7 Set-Cookie header it encounters (e.g. __Secure-typo3nonce
+        // added by RequestTokenMiddleware) and wipes the buffer. Doing the OAuth
+        // code exchange here and migrating the buffered cookies into the PSR-7
+        // response keeps the emitter from discarding them.
+        try {
+            $auth0 = ApplicationFactory::build(
+                $applicationId,
+                ApplicationFactory::SESSION_PREFIX_BACKEND,
+                $request
+            );
+            $auth0->exchange($issuer . self::PATH, $code, $state);
+            $response = $this->migrateBufferedCookiesToResponse($response);
+        } catch (\Throwable) {
+            // Exchange failed; let Auth0Provider report a missing session as login failure.
+        }
+
+        return $response;
+    }
+
+    /**
+     * Pulls Set-Cookie headers that were placed into PHP's header buffer (via
+     * setrawcookie() from inside the Auth0 SDK) into the PSR-7 response and
+     * removes them from the buffer, so the response emitter can manage them
+     * alongside Set-Cookie headers added by other middlewares.
+     */
+    private function migrateBufferedCookiesToResponse(ResponseInterface $response): ResponseInterface
+    {
+        $prefix = 'set-cookie:';
+        foreach (headers_list() as $header) {
+            if (stripos($header, $prefix) !== 0) {
+                continue;
+            }
+            $response = $response->withAddedHeader('Set-Cookie', trim(substr($header, strlen($prefix))));
+        }
+        header_remove('Set-Cookie');
+        return $response;
     }
 }

--- a/Classes/Middleware/CallbackMiddleware.php
+++ b/Classes/Middleware/CallbackMiddleware.php
@@ -25,12 +25,16 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
 use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Core\Http\Response;
 
-class CallbackMiddleware implements MiddlewareInterface
+class CallbackMiddleware implements MiddlewareInterface, LoggerAwareInterface
 {
+    use LoggerAwareTrait;
+
     public const PATH = '/auth0/callback';
 
     public const TOKEN_PARAMETER = 'token';
@@ -93,7 +97,7 @@ class CallbackMiddleware implements MiddlewareInterface
         $state = $queryParams['state'] ?? null;
         $applicationId = (int)($dataSet->get('application') ?? 0);
 
-        if ($code === null || $code === '' || $state === null || $applicationId === 0) {
+        if ($code === null || $code === '' || $state === null || $state === '' || $applicationId === 0) {
             return new RedirectResponse($redirectUri, 302);
         }
 
@@ -106,6 +110,7 @@ class CallbackMiddleware implements MiddlewareInterface
         // added by RequestTokenMiddleware) and wipes the buffer. Doing the OAuth
         // code exchange here and migrating the buffered cookies into the PSR-7
         // response keeps the emitter from discarding them.
+        $preExchangeCookies = $this->captureBufferedSetCookieHeaders();
         try {
             $auth0 = ApplicationFactory::build(
                 $applicationId,
@@ -113,30 +118,62 @@ class CallbackMiddleware implements MiddlewareInterface
                 $request
             );
             $auth0->exchange($issuer . self::PATH, $code, $state);
-            $response = $this->migrateBufferedCookiesToResponse($response);
-        } catch (\Throwable) {
-            // Exchange failed; let Auth0Provider report a missing session as login failure.
+            $response = $this->migrateBufferedCookiesToResponse($response, $preExchangeCookies);
+        } catch (\Throwable $throwable) {
+            $this->logger?->warning(
+                'Auth0 OAuth code exchange failed in CallbackMiddleware.',
+                ['exception' => $throwable]
+            );
         }
 
         return $response;
     }
 
     /**
-     * Pulls Set-Cookie headers that were placed into PHP's header buffer (via
-     * setrawcookie() from inside the Auth0 SDK) into the PSR-7 response and
-     * removes them from the buffer, so the response emitter can manage them
-     * alongside Set-Cookie headers added by other middlewares.
+     * @return list<string>
      */
-    private function migrateBufferedCookiesToResponse(ResponseInterface $response): ResponseInterface
+    private function captureBufferedSetCookieHeaders(): array
     {
         $prefix = 'set-cookie:';
+        $cookies = [];
+        foreach (headers_list() as $header) {
+            if (stripos($header, $prefix) === 0) {
+                $cookies[] = $header;
+            }
+        }
+        return $cookies;
+    }
+
+    /**
+     * Moves Set-Cookie headers that were queued in PHP's header buffer since
+     * $preExchangeCookies was captured into the PSR-7 response. Cookies that
+     * were already present before the exchange stay in the header buffer.
+     *
+     * @param list<string> $preExchangeCookies
+     */
+    private function migrateBufferedCookiesToResponse(
+        ResponseInterface $response,
+        array $preExchangeCookies,
+    ): ResponseInterface {
+        $prefix = 'set-cookie:';
+        $remaining = array_count_values($preExchangeCookies);
         foreach (headers_list() as $header) {
             if (stripos($header, $prefix) !== 0) {
+                continue;
+            }
+            if (($remaining[$header] ?? 0) > 0) {
+                $remaining[$header]--;
                 continue;
             }
             $response = $response->withAddedHeader('Set-Cookie', trim(substr($header, strlen($prefix))));
         }
         header_remove('Set-Cookie');
+        // Re-emit pre-existing Set-Cookie headers with replace=false. The original
+        // replace semantics are not preserved because the preceding TYPO3 middlewares
+        // queue distinct, additive cookies; no same-name overwrite is expected here.
+        foreach ($preExchangeCookies as $header) {
+            header($header, false);
+        }
         return $response;
     }
 }

--- a/Documentation/About/Changelog/14-0-4.rst
+++ b/Documentation/About/Changelog/14-0-4.rst
@@ -54,5 +54,6 @@ All Changes
 
 This is a list of all changes in this release::
 
+    2026-05-21 [TASK] Harden Auth0 backend callback flow [TER-482] [TER-483] (Commit 6fc3693 by Oliver Heins)
     2026-05-21 [DOCS] Document cookie-based Auth0 session storage [TER-482] [TER-483] (Commit d0b8f6e by Oliver Heins)
     2026-05-21 [BUGFIX] Switch storage to cookies; perform exchange in middleware [TER-482] [TER-483] (Commit c0e227e by Oliver Heins)

--- a/Documentation/About/Changelog/14-0-4.rst
+++ b/Documentation/About/Changelog/14-0-4.rst
@@ -1,0 +1,58 @@
+.. include:: ../../Includes.txt
+
+===========================
+Version 14.0.4 - 2026/05/21
+===========================
+
+This release resolves a conflict between the Auth0 OAuth session and the TYPO3
+Install Tool. Auth0 session state is no longer stored in PHP sessions but in
+encrypted cookies managed by the Auth0 SDK ``CookieStore``.
+
+Download
+========
+
+Download this version from the `TYPO3 extension repository <https://extensions.typo3.org/extension/auth0/>`__ or from
+`GitHub <https://github.com/Leuchtfeuer/auth0-for-typo3/releases/tag/v14.0.4>`__.
+
+Fixed
+=====
+
+* **Install Tool no longer crashes for Auth0-authenticated backend users:**
+  ``ApplicationFactory`` previously wired the Auth0 SDK with
+  :php:`Auth0\SDK\Store\SessionStore`, which calls :php:`session_start()` on the
+  first storage access. Once the Auth0 ``SudoModeRequiredEvent`` listener probed
+  that storage during a backend request, the PHP session stayed active. The
+  Install Tool's :php:`FileSessionHandler::__construct()` then called
+  :php:`session_save_path()` and PHP raised a warning that TYPO3's error handler
+  promoted to :php:`Exception` 1476107295, taking down the Maintenance, Upgrade,
+  Environment, and Settings modules. The session and transient stores are now
+  :php:`Auth0\SDK\Store\CookieStore` instances and never touch the PHP session.
+
+Changed
+=======
+
+* **OAuth code exchange moved into the callback middleware:** the exchange used
+  to run inside :php:`Auth0Provider::modifyView()` during view rendering. The
+  Auth0 SDK persists cookies via :php:`setrawcookie()`, but TYPO3's response
+  emitter calls :php:`header('Set-Cookie: ...', replace=true)` for the first
+  PSR-7 Set-Cookie header (e.g. ``__Secure-typo3nonce`` from
+  ``RequestTokenMiddleware``), wiping any Set-Cookie headers already queued in
+  PHP's header buffer. The callback middleware now runs the exchange itself and
+  migrates the buffered Auth0 cookies into the PSR-7 response so the emitter
+  carries them through alongside cookies added by other middlewares.
+
+Upgrade Notes
+=============
+
+* No database migration is required.
+
+* Existing Auth0 sessions are invalidated by the storage switch — backend users
+  authenticated via Auth0 need to log in once after the update.
+
+All Changes
+===========
+
+This is a list of all changes in this release::
+
+    2026-05-21 [DOCS] Document cookie-based Auth0 session storage [TER-482] [TER-483] (Commit d0b8f6e by Oliver Heins)
+    2026-05-21 [BUGFIX] Switch storage to cookies; perform exchange in middleware [TER-482] [TER-483] (Commit c0e227e by Oliver Heins)

--- a/Documentation/About/Changelog/Index.rst
+++ b/Documentation/About/Changelog/Index.rst
@@ -16,6 +16,7 @@ List of Versions
     :maxdepth: 3
     :titlesonly:
 
+    14-0-4
     14-0-3
     14-0-2
     14-0-1

--- a/Documentation/Admin/Index.rst
+++ b/Documentation/Admin/Index.rst
@@ -84,6 +84,37 @@ only TYPO3 backend users (for now).
 Please take a look at the :ref:`command <admin-command>` section.
 
 
+.. _admin-sessionStorage:
+
+Session Storage
+===============
+
+The Auth0 OAuth session (``id_token``, access token, user info) is held in
+encrypted, HTTP-only cookies named ``auth0_session_BE_*`` (and short-lived
+``auth0_session_BE_transient_*`` cookies during the login round trip). Payloads
+are encrypted with the TYPO3 encryption key
+(:php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']`) using AES-256-GCM,
+so no Auth0 data is readable client-side.
+
+Because Auth0 tokens can grow beyond the per-cookie size limit (~4 KB),
+the underlying SDK splits a single payload across several numbered cookies
+(``_0``, ``_1``, ``_2``, ...). Three to five cookies for a typical backend
+login are normal and well within the per-domain limit enforced by browsers.
+
+The ``Secure`` flag is derived from
+:php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['lockSSL']`, so cookies are only sent
+over HTTPS when the backend is configured for SSL. ``SameSite=Lax`` is used to
+let the OAuth callback round trip succeed.
+
+.. important::
+
+   Earlier versions persisted the OAuth session in PHP's native session storage.
+   That triggered :php:`session_start()` during backend requests and conflicted
+   with the TYPO3 Install Tool, whose :php:`FileSessionHandler` calls
+   :php:`session_save_path()` and fails when a PHP session is already active.
+   Updating from such a version invalidates any existing Auth0 sessions — users
+   need to log in once after the update.
+
 .. _admin-logging:
 
 Logging

--- a/Documentation/Developer/Index.rst
+++ b/Documentation/Developer/Index.rst
@@ -27,6 +27,13 @@ the request to derive the OAuth redirect URI via ``NormalizedParams``. If no req
 in CLI commands or early-boot contexts), ``$_SERVER`` is used as a last resort — the redirect URI
 is constructed but never used in an actual OAuth flow in those contexts.
 
+The returned :php:`Auth0` instance is wired with :php:`Auth0\SDK\Store\CookieStore` for both
+session and transient storage. ``cookieSecret`` defaults to TYPO3's encryption key, ``cookieSecure``
+follows :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['lockSSL']`, and ``cookieSameSite`` is ``Lax``.
+Subclasses overriding ``build()`` to provide a custom :php:`Auth0\SDK\Contract\StoreInterface` must
+not call :php:`session_start()` directly or indirectly — doing so re-introduces the conflict with
+the TYPO3 Install Tool's :php:`FileSessionHandler` (see :ref:`admin-sessionStorage`).
+
 .. _developer-api-tokenUtility:
 
 TokenUtility

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
     "extra": {
         "typo3/cms": {
             "extension-key": "auth0",
-            "version": "14.0.3",
+            "version": "14.0.4",
             "web-dir": ".Build/web"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -3,7 +3,7 @@
 $EM_CONF['auth0'] = [
     'title' => 'Auth0 for TYPO3',
     'description' => 'This extension allows you to log into a TYPO3 backend via Auth0. Auth0 is the solution you need for web, mobile, IoT, and internal applications. Loved by developers and trusted by enterprises.',
-    'version' => '14.0.3',
+    'version' => '14.0.4',
     'category' => 'misc',
     'constraints' => [
         'depends' => [


### PR DESCRIPTION
Auth0 SDK's PHP-session-backed storage called session_start() during backend requests, which broke the TYPO3 Install Tool's FileSessionHandler — session_save_path() throws when a session is already active. Switching the session and transient stores to the SDK's CookieStore avoids the PHP session entirely.