### PR TITLE
[BUGFIX] Only exchange Auth0 code when present on callback

### DIFF
--- a/Classes/Configuration/Auth0Configuration.php
+++ b/Classes/Configuration/Auth0Configuration.php
@@ -35,7 +35,7 @@ class Auth0Configuration implements SingletonInterface
 
     protected string $filePath;
 
-    public function __construct(string $configPath = null)
+    public function __construct(?string $configPath = null)
     {
         $this->configPath = $configPath ?? sprintf('%s/%s', Environment::getConfigPath(), self::CONFIG_FOLDER_NAME);
         $this->filePath = sprintf('%s/%s', $this->configPath, self::CONFIG_FILE_NAME);

--- a/Documentation/About/Changelog/13-0-11.rst
+++ b/Documentation/About/Changelog/13-0-11.rst
@@ -1,0 +1,29 @@
+.. include:: ../../Includes.txt
+
+============================
+Version 13.0.11 - 2026/06/30
+============================
+
+This release marks the ``Auth0Configuration`` constructor parameter as explicitly nullable to
+remove the implicit-nullable deprecation introduced with PHP 8.4.
+
+Download
+========
+
+Download this version from the `TYPO3 extension repository <https://extensions.typo3.org/extension/auth0/>`__ or from
+`GitHub <https://github.com/Leuchtfeuer/auth0-for-typo3/releases/tag/v13.0.11>`__.
+
+Fixed
+=====
+
+* **Explicitly mark nullable constructor parameter:** The ``$configPath`` parameter of
+  ``Auth0Configuration::__construct()`` now uses the explicit ``?string`` type instead of relying
+  on an implicit null default. This silences the implicit-nullable parameter deprecation raised by
+  PHP 8.4.
+
+All Changes
+===========
+
+This is a list of all changes in this release::
+
+    2026-06-30 [TASK] Explicitely mark nullable parameter [VS-7884] (Commit 3686a59 by Oliver Heins)

--- a/Documentation/About/Changelog/Index.rst
+++ b/Documentation/About/Changelog/Index.rst
@@ -16,6 +16,7 @@ List of Versions
     :maxdepth: 3
     :titlesonly:
 
+    13-0-11
     13-0-10
     13-0-9
     13-0-8

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
     "extra": {
         "typo3/cms": {
             "extension-key": "auth0",
-            "version": "13.0.10",
+            "version": "13.0.11",
             "web-dir": ".Build/web"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -3,7 +3,7 @@
 $EM_CONF['auth0'] = [
     'title' => 'Auth0 for TYPO3',
     'description' => 'This extension allows you to log into a TYPO3 backend via Auth0. Auth0 is the solution you need for web, mobile, IoT, and internal applications. Loved by developers and trusted by enterprises.',
-    'version' => '13.0.10',
+    'version' => '13.0.11',
     'category' => 'misc',
     'constraints' => [
         'depends' => [


### PR DESCRIPTION
Guards the Auth0 `exchange()` call so it only runs when a `code` query parameter is present. Prevents the SDK from throwing "Missing code" (logged as critical) on every plain backend login-form load.